### PR TITLE
update default babbage url

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,7 @@ package config
 var BindAddr = ":20000"
 
 // The URL of the babbage instance to use.
-var BabbageURL = "https://www.ons.gov.uk"
+var BabbageURL = "http://localhost:8080"
 
 // The URL of the content resolver.
 var ResolverURL = "http://localhost:20020"


### PR DESCRIPTION
### What

Update default babbage URL to be a local development environment not production

### How to review

Run babbage locally, it should use that!

### Who can review

Anyone except @ian-kent