### PR TITLE
add disabled page

### DIFF
--- a/assets/templates.go
+++ b/assets/templates.go
@@ -87,7 +87,7 @@ func templatesErrorTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/error.tmpl", size: 684, mode: os.FileMode(420), modTime: time.Unix(1485262263, 0)}
+	info := bindataFileInfo{name: "templates/error.tmpl", size: 684, mode: os.FileMode(420), modTime: time.Unix(1485422346, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -107,7 +107,7 @@ func templatesMainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/main.tmpl", size: 3324, mode: os.FileMode(420), modTime: time.Unix(1485262263, 0)}
+	info := bindataFileInfo{name: "templates/main.tmpl", size: 3324, mode: os.FileMode(420), modTime: time.Unix(1485422346, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -127,7 +127,7 @@ func templatesPartialsFooterTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/footer.tmpl", size: 2545, mode: os.FileMode(420), modTime: time.Unix(1485262263, 0)}
+	info := bindataFileInfo{name: "templates/partials/footer.tmpl", size: 2545, mode: os.FileMode(420), modTime: time.Unix(1485422346, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -147,7 +147,7 @@ func templatesPartialsHeaderTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 3493, mode: os.FileMode(420), modTime: time.Unix(1485262263, 0)}
+	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 3493, mode: os.FileMode(420), modTime: time.Unix(1485422346, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -25,3 +25,6 @@ var SiteDomain = "ons.gov.uk"
 
 // Splash page
 var SplashPage = ""
+
+// Disabled page
+var DisabledPage = ""

--- a/handlers/splash/handler.go
+++ b/handlers/splash/handler.go
@@ -11,9 +11,16 @@ import (
 	"github.com/ONSdigital/go-ns/log"
 )
 
-func Handler(splashPage string) func(http.Handler) http.Handler {
+func Handler(splashPage string, enabled bool) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if !enabled {
+				if err := callRenderer(w, req, splashPage); err != nil {
+					w.WriteHeader(500)
+				}
+				return
+			}
+
 			c, err := req.Cookie("splash")
 			if err != nil && err != http.ErrNoCookie {
 				log.ErrorR(req, err, nil)

--- a/main.go
+++ b/main.go
@@ -47,6 +47,9 @@ func main() {
 	if v := os.Getenv("SPLASH_PAGE"); len(v) > 0 {
 		config.SplashPage = v
 	}
+	if v := os.Getenv("DISABLED_PAGE"); len(v) > 0 {
+		config.DisabledPage = v
+	}
 
 	if v := os.Getenv("HOMEPAGE_AB_PERCENT"); len(v) > 0 {
 		a, _ := strconv.Atoi(v)
@@ -84,8 +87,10 @@ func main() {
 		serverError.Handler,
 		timeout.Handler(10 * time.Second),
 	}
-	if len(config.SplashPage) > 0 {
-		middleware = append(middleware, splash.Handler(config.SplashPage))
+	if len(config.DisabledPage) > 0 {
+		middleware = append(middleware, splash.Handler(config.DisabledPage, false))
+	} else if len(config.SplashPage) > 0 {
+		middleware = append(middleware, splash.Handler(config.SplashPage, true))
 	}
 	alice := alice.New(middleware...).Then(router)
 


### PR DESCRIPTION
### What

Add a disabled page to the router

### How to review

* Run dp-frontend-router and check the site works
* Run it with `SPLASH_PAGE=dd/alpha` and check the splash page works, and that clicking the button allows you to access the site
* Run it with `DISABLED_PAGE=dd/alpha` and check you get the splash page, and that clicking the button does nothing (cookie should still be set, but is ignored)

### Who can review

Anyone except @ian-kent