### PR TITLE
add X-Frame-Options header to all requests except /embed

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,6 +128,15 @@ func main() {
 	}
 }
 
+// securityHandler ...
+func securityHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/embed" {
+			w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		}
+	})
+}
+
 //abHandler ... percentA is the percentage of request that handler 'a' is used
 func abHandler(a, b http.Handler, percentA int) http.Handler {
 	if percentA == 0 {

--- a/main.go
+++ b/main.go
@@ -84,6 +84,7 @@ func main() {
 	middleware := []alice.Constructor{
 		requestID.Handler(16),
 		log.Handler,
+		securityHandler,
 		serverError.Handler,
 		timeout.Handler(10 * time.Second),
 	}

--- a/main.go
+++ b/main.go
@@ -135,6 +135,7 @@ func securityHandler(h http.Handler) http.Handler {
 		if req.URL.Path != "/embed" {
 			w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 		}
+		h.ServeHTTP(w, req)
 	})
 }
 


### PR DESCRIPTION
### What

Add X-Frame-Options header to responses except `/embed`

### How to review

* Run the router
* Check HTTP responses for correct header
* Check that `/embed` responses don't have the header

### Who can review

Anyone except @ian-kent
