### PR TITLE
fix splash cookie path handling

### DIFF
--- a/assets/debug.go
+++ b/assets/debug.go
@@ -33,7 +33,7 @@ type asset struct {
 
 // templatesErrorTmpl reads file data from disk. It returns an error on failure.
 func templatesErrorTmpl() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/error.tmpl"
+	path := "/Users/iankent/dev/src/github.com/ONSdigital/dp-frontend-router/assets/templates/error.tmpl"
 	name := "templates/error.tmpl"
 	bytes, err := bindataRead(path, name)
 	if err != nil {
@@ -51,7 +51,7 @@ func templatesErrorTmpl() (*asset, error) {
 
 // templatesMainTmpl reads file data from disk. It returns an error on failure.
 func templatesMainTmpl() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/main.tmpl"
+	path := "/Users/iankent/dev/src/github.com/ONSdigital/dp-frontend-router/assets/templates/main.tmpl"
 	name := "templates/main.tmpl"
 	bytes, err := bindataRead(path, name)
 	if err != nil {
@@ -69,7 +69,7 @@ func templatesMainTmpl() (*asset, error) {
 
 // templatesPartialsFooterTmpl reads file data from disk. It returns an error on failure.
 func templatesPartialsFooterTmpl() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/partials/footer.tmpl"
+	path := "/Users/iankent/dev/src/github.com/ONSdigital/dp-frontend-router/assets/templates/partials/footer.tmpl"
 	name := "templates/partials/footer.tmpl"
 	bytes, err := bindataRead(path, name)
 	if err != nil {
@@ -87,7 +87,7 @@ func templatesPartialsFooterTmpl() (*asset, error) {
 
 // templatesPartialsHeaderTmpl reads file data from disk. It returns an error on failure.
 func templatesPartialsHeaderTmpl() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/partials/header.tmpl"
+	path := "/Users/iankent/dev/src/github.com/ONSdigital/dp-frontend-router/assets/templates/partials/header.tmpl"
 	name := "templates/partials/header.tmpl"
 	bytes, err := bindataRead(path, name)
 	if err != nil {

--- a/handlers/splash/handler.go
+++ b/handlers/splash/handler.go
@@ -41,7 +41,7 @@ func Handler(splashPage string, enabled bool) func(http.Handler) http.Handler {
 					}
 					return
 				}
-				http.SetCookie(w, &http.Cookie{Name: "splash", Value: "y"})
+				http.SetCookie(w, &http.Cookie{Name: "splash", Value: "y", Path: "/"})
 				http.Redirect(w, req, req.URL.String(), http.StatusFound)
 				return
 			}


### PR DESCRIPTION
### What

Set cookie path

### How to review

- clear `splash` cookie
- open a page on a non-root URL (e.g. `/economy/grossdomesticproductgdp`)
- check cookie path is `/`

### Who can review

Anyone except @ian-kent
