### PR TITLE
fix sameorigin bug

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ONSdigital/dp-frontend-router/assets"
@@ -131,7 +132,7 @@ func main() {
 // securityHandler ...
 func securityHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.URL.Path != "/embed" {
+		if req.URL.Path != "/embed" && !strings.HasPrefix(req.URL.Path, "/visualisations/") {
 			w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 		}
 		h.ServeHTTP(w, req)


### PR DESCRIPTION
### What

Prevent sameorigin header being returned for visualisations

### How to review

- Run locally
- Check anything under /visualisations doesn't return X-Frame-Options header

### Who can review

Anyone except @ian-kent
