### PR TITLE
Feature/performance fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,6 +82,7 @@ func main() {
 
 	log.Namespace = "dp-frontend-router"
 
+	log.Debug("overriding default renderer with service assets", nil)
 	render.Renderer = unrolled.New(unrolled.Options{
 		Asset:         assets.Asset,
 		AssetNames:    assets.AssetNames,

--- a/middleware/serverError/handler.go
+++ b/middleware/serverError/handler.go
@@ -6,15 +6,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"sync"
 
 	"github.com/ONSdigital/dp-frontend-router/config"
 	"github.com/ONSdigital/dp-frontend-router/lang"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/ONSdigital/go-ns/render"
 )
-
-var mutex = &sync.Mutex{}
 
 type responseInterceptor struct {
 	http.ResponseWriter

--- a/middleware/serverError/handler.go
+++ b/middleware/serverError/handler.go
@@ -45,11 +45,6 @@ func (rI *responseInterceptor) renderErrorPage(code int, title, description stri
 		log.ErrorR(rI.req, err, nil)
 		log.DebugR(rI.req, "rendering disaster page", nil)
 
-		// There is a race condition going on in render.HTML
-		// lock access to it until resource is released
-		mutex.Lock()
-		defer mutex.Unlock()
-
 		// Calling the renderer failed, render the disaster page
 		err = render.HTML(rI.ResponseWriter, code, "error", map[string]interface{}{
 			"URI":                      rI.req.URL.Path,

--- a/vendor/github.com/ONSdigital/go-ns/render/render.go
+++ b/vendor/github.com/ONSdigital/go-ns/render/render.go
@@ -1,9 +1,37 @@
+// Package render allows the rendering of different template formats through a given interface
 package render
 
 import (
+	"html/template"
 	"io"
+	"sync"
 
+	"github.com/ONSdigital/go-ns/log"
 	"github.com/unrolled/render"
+)
+
+func init() {
+	// If the renderer is nil, provide a default to avoid nil pointer panic
+	if Renderer == nil {
+		Renderer = render.New(render.Options{
+			Layout: "main",
+			Funcs: []template.FuncMap{{
+				"safeHTML": func(s string) template.HTML {
+					return template.HTML(s)
+				},
+			}},
+		})
+
+		log.Debug("creating default unrolled renderer", nil)
+	}
+}
+
+var (
+	// Since the unrolled renderer can lead to race conditions with
+	// concurrent requests, lock resource access until template has
+	// been sucessfully rendered
+	hMutex = &sync.Mutex{}
+	jMutex = &sync.Mutex{}
 )
 
 type renderer interface {
@@ -11,15 +39,20 @@ type renderer interface {
 	JSON(w io.Writer, status int, v interface{}) error
 }
 
-//Renderer ...
+// Renderer provides an instance of the renderer interface used to allow the rendering of
+// HTML and JSON templates
 var Renderer renderer
 
-//HTML ...
+// HTML controls the rendering of an HTML template with a given name and template parameters to an io.Writer
 func HTML(w io.Writer, status int, name string, binding interface{}, htmlOpt ...render.HTMLOptions) error {
+	hMutex.Lock()
+	defer hMutex.Unlock()
 	return Renderer.HTML(w, status, name, binding, htmlOpt...)
 }
 
-//JSON ...
+// JSON controls the rendering of a JSON template with a given name and template parameters to an io.Writer
 func JSON(w io.Writer, status int, v interface{}) error {
+	jMutex.Lock()
+	defer jMutex.Unlock()
 	return Renderer.JSON(w, status, v)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -33,10 +33,10 @@
 			"revisionTime": "2017-08-30T09:50:52Z"
 		},
 		{
-			"checksumSHA1": "bc51V8C9zf7U4bbsblh+7Cbe9lM=",
+			"checksumSHA1": "YtiRks0ZOuqkOz5OJHooyGnL6J0=",
 			"path": "github.com/ONSdigital/go-ns/render",
-			"revision": "bc66177e78ff92143848188c78ac5f112ce8ef4c",
-			"revisionTime": "2017-01-23T15:55:35Z"
+			"revision": "bc738aa12b6d88fb7a8a55f0bb4ea47b08e210af",
+			"revisionTime": "2017-11-22T09:55:22Z"
 		},
 		{
 			"checksumSHA1": "kfEPqmTD+a9Mo+pqCeiJb6OGrDE=",


### PR DESCRIPTION
### What

Fixed some major performance issues found under load testing.
- Prevent any routes beginning with /datasets /filters /feedback or /healthcheck going through zebedee as middleware
- Place a mutex lock before rendering template using unrolled renderer to avoid race condition with concurrent requests

### How to review

Download https://k6.io/

Create a file called webtest.js with the following in:

```js
import { check , sleep } from "k6";
import http from "k6/http";

export let options = {
        stages: [
                { duration: "30s", target: 20},
                { duration: "1m30s", target: 10},
                { duration: "20s", target: 0},
        ]
};

export default function() {
        let res = http.get("http://localhost:20000/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c");
        check(res, {
                "status was 200": (r) => r.status == 200
        });
        sleep(1);
}
```

Run the full stack (websysd) with the router and renderer running on feature/performance-fixes
Run `k6 run webtest.js`
Verify that the performance test passes (You will need a dataset with id: 95c4669b-3ae9-4ba7-b690-87e890a1c67c)

### Who can review

Anyone