### PR TITLE
return the correct status code for downstream errors

### DIFF
--- a/assets/debug.go
+++ b/assets/debug.go
@@ -34,7 +34,7 @@ type asset struct {
 
 // templatesErrorTmpl reads file data from disk. It returns an error on failure.
 func templatesErrorTmpl() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/error.tmpl"
+	path := "/Users/iankent/dev/src/github.com/ONSdigital/dp-frontend-router/assets/templates/error.tmpl"
 	name := "templates/error.tmpl"
 	bytes, err := bindataRead(path, name)
 	if err != nil {
@@ -52,7 +52,7 @@ func templatesErrorTmpl() (*asset, error) {
 
 // templatesMainTmpl reads file data from disk. It returns an error on failure.
 func templatesMainTmpl() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/main.tmpl"
+	path := "/Users/iankent/dev/src/github.com/ONSdigital/dp-frontend-router/assets/templates/main.tmpl"
 	name := "templates/main.tmpl"
 	bytes, err := bindataRead(path, name)
 	if err != nil {
@@ -70,7 +70,7 @@ func templatesMainTmpl() (*asset, error) {
 
 // templatesPartialsFooterTmpl reads file data from disk. It returns an error on failure.
 func templatesPartialsFooterTmpl() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/partials/footer.tmpl"
+	path := "/Users/iankent/dev/src/github.com/ONSdigital/dp-frontend-router/assets/templates/partials/footer.tmpl"
 	name := "templates/partials/footer.tmpl"
 	bytes, err := bindataRead(path, name)
 	if err != nil {
@@ -88,7 +88,7 @@ func templatesPartialsFooterTmpl() (*asset, error) {
 
 // templatesPartialsHeaderTmpl reads file data from disk. It returns an error on failure.
 func templatesPartialsHeaderTmpl() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/partials/header.tmpl"
+	path := "/Users/iankent/dev/src/github.com/ONSdigital/dp-frontend-router/assets/templates/partials/header.tmpl"
 	name := "templates/partials/header.tmpl"
 	bytes, err := bindataRead(path, name)
 	if err != nil {
@@ -106,7 +106,7 @@ func templatesPartialsHeaderTmpl() (*asset, error) {
 
 // redirectsRedirectsCsv reads file data from disk. It returns an error on failure.
 func redirectsRedirectsCsv() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/redirects/redirects.csv"
+	path := "/Users/iankent/dev/src/github.com/ONSdigital/dp-frontend-router/assets/redirects/redirects.csv"
 	name := "redirects/redirects.csv"
 	bytes, err := bindataRead(path, name)
 	if err != nil {

--- a/assets/templates.go
+++ b/assets/templates.go
@@ -88,7 +88,7 @@ func templatesErrorTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/error.tmpl", size: 684, mode: os.FileMode(420), modTime: time.Unix(1485422425, 0)}
+	info := bindataFileInfo{name: "templates/error.tmpl", size: 684, mode: os.FileMode(420), modTime: time.Unix(1502693960, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -108,7 +108,7 @@ func templatesMainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/main.tmpl", size: 3324, mode: os.FileMode(420), modTime: time.Unix(1485422425, 0)}
+	info := bindataFileInfo{name: "templates/main.tmpl", size: 3324, mode: os.FileMode(420), modTime: time.Unix(1502693960, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -128,7 +128,7 @@ func templatesPartialsFooterTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/footer.tmpl", size: 2545, mode: os.FileMode(420), modTime: time.Unix(1485422425, 0)}
+	info := bindataFileInfo{name: "templates/partials/footer.tmpl", size: 2545, mode: os.FileMode(420), modTime: time.Unix(1502693960, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -148,7 +148,7 @@ func templatesPartialsHeaderTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 3874, mode: os.FileMode(420), modTime: time.Unix(1505306210, 0)}
+	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 3874, mode: os.FileMode(420), modTime: time.Unix(1502693960, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -168,7 +168,7 @@ func redirectsRedirectsCsv() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "redirects/redirects.csv", size: 17871, mode: os.FileMode(420), modTime: time.Unix(1511865925, 0)}
+	info := bindataFileInfo{name: "redirects/redirects.csv", size: 17871, mode: os.FileMode(420), modTime: time.Unix(1513072243, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/handlers/serverError/handler.go
+++ b/handlers/serverError/handler.go
@@ -98,7 +98,7 @@ func (rI *responseInterceptor) callRenderer(code int, title, description string)
 	}
 
 	log.DebugR(rI.req, "returning error page", nil)
-	rI.ResponseWriter.WriteHeader(res.StatusCode)
+	rI.ResponseWriter.WriteHeader(code)
 	rI.ResponseWriter.Write(b)
 
 	return nil


### PR DESCRIPTION
### What

Return the correct status code when a downstream service returns an error (i.e. stop returning a 200 response for an internal server error page)

### How to review

* Start dp-frontend-router
* Start dp-frontend-renderer
* `curl localhost:20000` should return a 500 error
* Stop dp-frontend-renderer
* `curl localhost:20000` should also return a 500 error

### Who can review

Anyone except @ian-kent
