### PR TITLE
Feature/add hsts header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build: generate
 
 debug: generate
 	go build -tags 'debug' -o $(BINPATH)/dp-frontend-router
-	HUMAN_LOG=1 DEBUG=1 $(BINPATH)/dp-frontend-router
+	DISABLE_HSTS_HEADER=true HUMAN_LOG=1 DEBUG=1 $(BINPATH)/dp-frontend-router
 
 generate: ${GOPATH}/bin/go-bindata
 	# build the production version

--- a/assets/templates.go
+++ b/assets/templates.go
@@ -88,7 +88,7 @@ func templatesErrorTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/error.tmpl", size: 684, mode: os.FileMode(420), modTime: time.Unix(1502693960, 0)}
+	info := bindataFileInfo{name: "templates/error.tmpl", size: 684, mode: os.FileMode(420), modTime: time.Unix(1513155567, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -108,7 +108,7 @@ func templatesMainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/main.tmpl", size: 3324, mode: os.FileMode(420), modTime: time.Unix(1502693960, 0)}
+	info := bindataFileInfo{name: "templates/main.tmpl", size: 3324, mode: os.FileMode(420), modTime: time.Unix(1513155567, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -128,7 +128,7 @@ func templatesPartialsFooterTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/footer.tmpl", size: 2545, mode: os.FileMode(420), modTime: time.Unix(1502693960, 0)}
+	info := bindataFileInfo{name: "templates/partials/footer.tmpl", size: 2545, mode: os.FileMode(420), modTime: time.Unix(1513155567, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -148,7 +148,7 @@ func templatesPartialsHeaderTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 3874, mode: os.FileMode(420), modTime: time.Unix(1502693960, 0)}
+	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 3874, mode: os.FileMode(420), modTime: time.Unix(1513155567, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -168,7 +168,7 @@ func redirectsRedirectsCsv() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "redirects/redirects.csv", size: 17871, mode: os.FileMode(420), modTime: time.Unix(1513073613, 0)}
+	info := bindataFileInfo{name: "redirects/redirects.csv", size: 17871, mode: os.FileMode(420), modTime: time.Unix(1513155567, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -37,3 +37,6 @@ var SplashPage = ""
 
 // Disabled page
 var DisabledPage = ""
+
+// Disable HSTS header
+var DisableHSTSHeader = false

--- a/main.go
+++ b/main.go
@@ -80,6 +80,11 @@ func main() {
 		log.Error(err, nil)
 	}
 
+	config.DisableHSTSHeader, err = strconv.ParseBool(os.Getenv("DISABLE_HSTS_HEADER"))
+	if err != nil {
+		log.Error(err, nil)
+	}
+
 	log.Namespace = "dp-frontend-router"
 
 	log.Debug("overriding default renderer with service assets", nil)
@@ -167,6 +172,9 @@ func securityHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.URL.Path != "/embed" && !strings.HasPrefix(req.URL.Path, "/visualisations/") {
 			w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		}
+		if !config.DisableHSTSHeader {
+			w.Header().Set("Strict-Transport-Security", "max-age=31536000")
 		}
 		h.ServeHTTP(w, req)
 	})

--- a/main.go
+++ b/main.go
@@ -158,6 +158,7 @@ func main() {
 		"site_domain":            config.SiteDomain,
 		"assets_path":            config.PatternLibraryAssetsPath,
 		"splash_page":            config.SplashPage,
+		"disable_hsts_header":    config.DisableHSTSHeader,
 	})
 
 	s := server.New(config.BindAddr, alice)

--- a/middleware/redirects/redirects_test.go
+++ b/middleware/redirects/redirects_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/ONSdigital/dp-frontend-router/handlers/serverError"
+	"github.com/ONSdigital/dp-frontend-router/middleware/serverError"
 	"github.com/ONSdigital/go-ns/handlers/requestID"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gorilla/pat"


### PR DESCRIPTION
### What

Add `Strict-Transport-Security` header to all responses

### How to review

* Run `make test`
* `curl -v 1>/dev/null` *should not* include `Strict-Transport-Security: max-age=31536000`
* Run `build/dp-frontend-router`
* `curl -v 1>/dev/null` *should* include `Strict-Transport-Security: max-age=31536000`

### Who can review

Anyone except @ian-kent
