### PR TITLE
new redirect for /lifestyle

### DIFF
--- a/assets/redirects/redirects.csv
+++ b/assets/redirects/redirects.csv
@@ -94,3 +94,4 @@
 /ons/apiservice/web/apiservice/home,/help/localstatistics
 /ons/index.html,/
 /economy/inflationandpriceindices/qmis/consumerpriceinflationqmi,/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi
+/lifestyle,/aboutus/whatwedo/programmesandprojects/onlineopinionsandlifestylestudy


### PR DESCRIPTION
What
New shortcut. Replacement for https://github.com/ONSdigital/babbage/pull/168

How to review
Link
www.ons.gov.uk/lifestyle
to
www.ons.gov.uk/aboutus/whatwedo/programmesandprojects/onlineopinionsandlifestylestudy

Who can review
I did it, so basically anyone.