### PR TITLE
feature/remove-hsts-header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build: generate
 
 debug: generate
 	go build -tags 'debug' -o $(BINPATH)/dp-frontend-router
-	DISABLE_HSTS_HEADER=true HUMAN_LOG=1 DEBUG=1 $(BINPATH)/dp-frontend-router
+	HUMAN_LOG=1 DEBUG=1 $(BINPATH)/dp-frontend-router
 
 generate: ${GOPATH}/bin/go-bindata
 	# build the production version

--- a/config/config.go
+++ b/config/config.go
@@ -44,9 +44,6 @@ var RedirectSecret = "secret"
 // Disabled page
 var DisabledPage = ""
 
-// Disable HSTS header
-var DisableHSTSHeader = false
-
 // TaxonomyDomain is link to website. Used for CMD beta so global links go to website rather than beta domain
 var TaxonomyDomain = ""
 

--- a/main.go
+++ b/main.go
@@ -93,11 +93,6 @@ func main() {
 		log.Error(err, nil)
 	}
 
-	config.DisableHSTSHeader, err = strconv.ParseBool(os.Getenv("DISABLE_HSTS_HEADER"))
-	if err != nil {
-		log.Error(err, nil)
-	}
-
 	if v := os.Getenv("TAXONOMY_DOMAIN"); len(v) > 0 {
 		config.TaxonomyDomain = v
 	}
@@ -189,7 +184,6 @@ func main() {
 		"site_domain":            config.SiteDomain,
 		"assets_path":            config.PatternLibraryAssetsPath,
 		"splash_page":            config.SplashPage,
-		"disable_hsts_header":    config.DisableHSTSHeader,
 		"taxonomy_domain":        config.TaxonomyDomain,
 		"analytics_sqs_url":      config.SQSAnalyticsURL,
 	})
@@ -206,9 +200,6 @@ func securityHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.URL.Path != "/embed" && !strings.HasPrefix(req.URL.Path, "/visualisations/") {
 			w.Header().Set("X-Frame-Options", "SAMEORIGIN")
-		}
-		if !config.DisableHSTSHeader {
-			w.Header().Set("Strict-Transport-Security", "max-age=31536000")
 		}
 		h.ServeHTTP(w, req)
 	})


### PR DESCRIPTION
### What

Remove HTTP Strict Transport Security header. This header is common for all services that are accessible by the public so it is set at the proxy level. This helps us avoid duplicating common headers across service implementations.

### How to review

Code review. Verify the header and its related configuration has been removed.

### Who can review

Not me.
