### PR TITLE
Prevent reflective XSS attacks

### DIFF
--- a/assets/debug.go
+++ b/assets/debug.go
@@ -34,7 +34,7 @@ type asset struct {
 
 // templatesErrorTmpl reads file data from disk. It returns an error on failure.
 func templatesErrorTmpl() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/error.tmpl"
+	path := "/Users/danielwalford/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/error.tmpl"
 	name := "templates/error.tmpl"
 	bytes, err := bindataRead(path, name)
 	if err != nil {
@@ -52,7 +52,7 @@ func templatesErrorTmpl() (*asset, error) {
 
 // templatesMainTmpl reads file data from disk. It returns an error on failure.
 func templatesMainTmpl() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/main.tmpl"
+	path := "/Users/danielwalford/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/main.tmpl"
 	name := "templates/main.tmpl"
 	bytes, err := bindataRead(path, name)
 	if err != nil {
@@ -70,7 +70,7 @@ func templatesMainTmpl() (*asset, error) {
 
 // templatesPartialsFooterTmpl reads file data from disk. It returns an error on failure.
 func templatesPartialsFooterTmpl() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/partials/footer.tmpl"
+	path := "/Users/danielwalford/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/partials/footer.tmpl"
 	name := "templates/partials/footer.tmpl"
 	bytes, err := bindataRead(path, name)
 	if err != nil {
@@ -88,7 +88,7 @@ func templatesPartialsFooterTmpl() (*asset, error) {
 
 // templatesPartialsHeaderTmpl reads file data from disk. It returns an error on failure.
 func templatesPartialsHeaderTmpl() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/partials/header.tmpl"
+	path := "/Users/danielwalford/go/src/github.com/ONSdigital/dp-frontend-router/assets/templates/partials/header.tmpl"
 	name := "templates/partials/header.tmpl"
 	bytes, err := bindataRead(path, name)
 	if err != nil {
@@ -106,7 +106,7 @@ func templatesPartialsHeaderTmpl() (*asset, error) {
 
 // redirectsRedirectsCsv reads file data from disk. It returns an error on failure.
 func redirectsRedirectsCsv() (*asset, error) {
-	path := "/Users/jon/go/src/github.com/ONSdigital/dp-frontend-router/assets/redirects/redirects.csv"
+	path := "/Users/danielwalford/go/src/github.com/ONSdigital/dp-frontend-router/assets/redirects/redirects.csv"
 	name := "redirects/redirects.csv"
 	bytes, err := bindataRead(path, name)
 	if err != nil {

--- a/assets/templates.go
+++ b/assets/templates.go
@@ -88,7 +88,7 @@ func templatesErrorTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/error.tmpl", size: 684, mode: os.FileMode(420), modTime: time.Unix(1519374285, 0)}
+	info := bindataFileInfo{name: "templates/error.tmpl", size: 684, mode: os.FileMode(420), modTime: time.Unix(1552397013, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -108,7 +108,7 @@ func templatesMainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/main.tmpl", size: 3385, mode: os.FileMode(420), modTime: time.Unix(1553529115, 0)}
+	info := bindataFileInfo{name: "templates/main.tmpl", size: 3385, mode: os.FileMode(420), modTime: time.Unix(1556015904, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -128,7 +128,7 @@ func templatesPartialsFooterTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/footer.tmpl", size: 3865, mode: os.FileMode(420), modTime: time.Unix(1553529029, 0)}
+	info := bindataFileInfo{name: "templates/partials/footer.tmpl", size: 3865, mode: os.FileMode(420), modTime: time.Unix(1556015904, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -148,7 +148,7 @@ func templatesPartialsHeaderTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 3958, mode: os.FileMode(420), modTime: time.Unix(1553529029, 0)}
+	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 3958, mode: os.FileMode(420), modTime: time.Unix(1556015904, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -168,7 +168,7 @@ func redirectsRedirectsCsv() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "redirects/redirects.csv", size: 21885, mode: os.FileMode(420), modTime: time.Unix(1553529115, 0)}
+	info := bindataFileInfo{name: "redirects/redirects.csv", size: 21885, mode: os.FileMode(420), modTime: time.Unix(1556099962, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/middleware/serverError/handler.go
+++ b/middleware/serverError/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/ONSdigital/dp-frontend-router/config"
 	"github.com/ONSdigital/dp-frontend-router/lang"
@@ -26,7 +27,7 @@ func (rI *responseInterceptor) WriteHeader(status int) {
 		log.DebugR(rI.req, "Intercepted error response", log.Data{"status": status})
 		rI.intercepted = true
 		if status == 500 {
-			rI.renderErrorPage(500, "Internal server error", "<p>We're currently experiencing some technical difficulties. You could try <a href='"+rI.req.Host+rI.req.URL.Path+"'>refreshing the page or trying again later.</a> </p>")
+			rI.renderErrorPage(500, "Internal server error", "<p>We're currently experiencing some technical difficulties. You could try <a href='"+rI.req.Host+url.QueryEscape(rI.req.URL.Path)+"'>refreshing the page or trying again later.</a> </p>")
 		} else if status == 404 {
 			rI.renderErrorPage(404, "404 - The webpage you are requesting does not exist on the site", `<p> The page may have been moved, updated or deleted or you may have typed the web address incorrectly, please check the url and spelling. Alternatively, please try the search, or return to the <a href="/" title="Our homepage" target="_self">homepage</a> and use the sitemap.</p>`)
 		} else if status == 401 {


### PR DESCRIPTION
### What

Prevent reflective Cross-Site Scripting attacks when a user gets a 500 page via a link to the website.
Escaped URL on the 500 page.

### How to review

1. Pull this PR and run it locally, publish a dataset and go to a link like:
2. Open Firefox
3. Navigate to a page similar to: http://{domain}:{port}/datasets/cpih01/edditions/time-series/versions/19%25%7dcfv57'%3E%3Cscript%3Ealert(1)%3C/script%3E
3.a note anything that triggers a 500 page add:
 ` %25%7dcfv57'%3E%3Cscript%3Ealert(1)%3C/script%3E ` at the end 
4. You should not recieve an alert. Open up the dev console in browser inspect the refresh link, you should see something like this which includes: `%25%7Dcfv57%27%3E%3Cscript%3Ealert%281%29%3C%2Fscript%3E`
<img width="771" alt="Screenshot 2019-04-29 at 10 23 52" src="https://user-images.githubusercontent.com/47502916/56887212-e99c7a00-6a68-11e9-8b56-e655cb6f9fac.png">

### Who can review

Anyone except me