### PR TITLE
Feature/add cookies route

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ type Config struct {
 	BabbageURL                 string `envconfig:"BABBAGE_URL"`
 	RendererURL                string `envconfig:"RENDERER_URL"`
 	CookiesControllerURL       string `envconfig:"COOKIES_CONTROLLER_URL"`
-	CookiesRoutesEnabled       bool   `envconfig:"COOKIES_CONTROL_ENABLED"`
+	CookiesRoutesEnabled       bool   `envconfig:"COOKIES_ROUTES_ENABLED"`
 	DatasetRoutesEnabled       bool   `envconfig:"DATASET_ROUTES_ENABLED"`
 	DatasetControllerURL       string `envconfig:"DATASET_CONTROLLER_URL"`
 	FilterDatasetControllerURL string `envconfig:"FILTER_DATASET_CONTROLLER_URL"`

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	BindAddr                   string `envconfig:"BIND_ADDR"`
 	BabbageURL                 string `envconfig:"BABBAGE_URL"`
 	RendererURL                string `envconfig:"RENDERER_URL"`
+	CookiesControllerURL       string `envconfig:"COOKIES_CONTROLLER_URL"`
 	DatasetRoutesEnabled       bool   `envconfig:"DATASET_ROUTES_ENABLED"`
 	DatasetControllerURL       string `envconfig:"DATASET_CONTROLLER_URL"`
 	FilterDatasetControllerURL string `envconfig:"FILTER_DATASET_CONTROLLER_URL"`
@@ -35,6 +36,7 @@ func Get() (*Config, error) {
 		BindAddr:                   ":20000",
 		BabbageURL:                 "http://localhost:8080",
 		RendererURL:                "http://localhost:20010",
+		CookiesControllerURL:       "http://localhost:23800",
 		DatasetRoutesEnabled:       false,
 		DatasetControllerURL:       "http://localhost:20200",
 		FilterDatasetControllerURL: "http://localhost:20001",

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	BabbageURL                 string `envconfig:"BABBAGE_URL"`
 	RendererURL                string `envconfig:"RENDERER_URL"`
 	CookiesControllerURL       string `envconfig:"COOKIES_CONTROLLER_URL"`
+	CookiesRoutesEnabled       bool   `envconfig:"COOKIES_CONTROL_ENABLED"`
 	DatasetRoutesEnabled       bool   `envconfig:"DATASET_ROUTES_ENABLED"`
 	DatasetControllerURL       string `envconfig:"DATASET_CONTROLLER_URL"`
 	FilterDatasetControllerURL string `envconfig:"FILTER_DATASET_CONTROLLER_URL"`
@@ -37,6 +38,7 @@ func Get() (*Config, error) {
 		BabbageURL:                 "http://localhost:8080",
 		RendererURL:                "http://localhost:20010",
 		CookiesControllerURL:       "http://localhost:23800",
+		CookiesRoutesEnabled:       false,
 		DatasetRoutesEnabled:       false,
 		DatasetControllerURL:       "http://localhost:20200",
 		FilterDatasetControllerURL: "http://localhost:20001",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,6 +20,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.BindAddr, ShouldEqual, ":20000")
 				So(cfg.BabbageURL, ShouldEqual, "http://localhost:8080")
 				So(cfg.RendererURL, ShouldEqual, "http://localhost:20010")
+				So(cfg.CookiesControllerURL, ShouldEqual, "http://localhost:23800")
 				So(cfg.DatasetRoutesEnabled, ShouldEqual, false)
 				So(cfg.DatasetControllerURL, ShouldEqual, "http://localhost:20200")
 				So(cfg.FilterDatasetControllerURL, ShouldEqual, "http://localhost:20001")

--- a/main.go
+++ b/main.go
@@ -103,7 +103,10 @@ func main() {
 	reverseProxy := createReverseProxy("babbage", babbageURL)
 	router.Handle("/redir/{data:.*}", searchHandler)
 	router.Handle("/download/{uri:.*}", createReverseProxy("download", downloaderURL))
-	router.Handle("/cookie/{uri:.*}", createReverseProxy("cookie", cookiesControllerURL))
+
+	if cfg.CookiesRoutesEnabled {
+		router.Handle("/cookies/{uri:.*}", createReverseProxy("cookie", cookiesControllerURL))
+	}
 
 	if cfg.DatasetRoutesEnabled {
 		router.Handle("/datasets/{uri:.*}", createReverseProxy("datasets", datasetControllerURL))

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 	router.Handle("/download/{uri:.*}", createReverseProxy("download", downloaderURL))
 
 	if cfg.CookiesRoutesEnabled {
-		router.Handle("/cookies/{uri:.*}", createReverseProxy("cookie", cookiesControllerURL))
+		router.Handle("/cookies/{uri:.*}", createReverseProxy("cookies", cookiesControllerURL))
 	}
 
 	if cfg.DatasetRoutesEnabled {

--- a/main.go
+++ b/main.go
@@ -37,6 +37,12 @@ func main() {
 
 	log.Event(ctx, "got service configuration", log.Data{"config": cfg})
 
+	cookiesControllerURL, err := url.Parse(cfg.CookiesControllerURL)
+	if err != nil {
+		log.Event(nil, "configuration value is invalid", log.Data{"config_name": "CookiesControllerURL", "value": cfg.CookiesControllerURL}, log.Error(err))
+		os.Exit(1)
+	}
+
 	datasetControllerURL, err := url.Parse(cfg.DatasetControllerURL)
 	if err != nil {
 		log.Event(nil, "configuration value is invalid", log.Data{"config_name": "DatasetControllerURL", "value": cfg.DatasetControllerURL}, log.Error(err))
@@ -97,6 +103,7 @@ func main() {
 	reverseProxy := createReverseProxy("babbage", babbageURL)
 	router.Handle("/redir/{data:.*}", searchHandler)
 	router.Handle("/download/{uri:.*}", createReverseProxy("download", downloaderURL))
+	router.Handle("/cookie/{uri:.*}", createReverseProxy("cookie", cookiesControllerURL))
 
 	if cfg.DatasetRoutesEnabled {
 		router.Handle("/datasets/{uri:.*}", createReverseProxy("datasets", datasetControllerURL))


### PR DESCRIPTION
### What

- Updated config to include cookies controller URL and feature flag
- Added `/cookies/{uri:.*}` route for cookies controller endpoints

### How to review

- Check that code works and aligns with the pattern used for other routes
- You can check the route works by running the site with the cookies controller and Babbage/Renderer with the `EnableCookiesControl` flag set to true. The router would also need `CookiesRoutesEnabled` set to `true`, as well. The cookies banner should then be rendered and let you trigger a GET via the "Accept all" button.

### Who can review

Anyone bar me
