### PR TITLE
serverError reintroduced

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"github.com/ONSdigital/dp-frontend-router/middleware/serverError"
 	"math/rand"
 	"net"
 	"net/http"
@@ -23,6 +24,7 @@ import (
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/pat"
 	"github.com/justinas/alice"
+
 )
 
 var (
@@ -91,6 +93,7 @@ func main() {
 		requestID.Handler(16),
 		log.Middleware,
 		securityHandler,
+		serverError.Handler,
 		redirects.Handler,
 	}
 

--- a/middleware/serverError/handler.go
+++ b/middleware/serverError/handler.go
@@ -5,13 +5,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
-
 	"github.com/ONSdigital/dp-frontend-router/config"
 	"github.com/ONSdigital/dp-frontend-router/lang"
 	"github.com/ONSdigital/log.go/log"
+	"io/ioutil"
+	"net/http"
 )
 
 type responseInterceptor struct {
@@ -26,16 +24,13 @@ func (rI *responseInterceptor) WriteHeader(status int) {
 	if status >= 400 {
 		log.Event(rI.req.Context(), "Intercepted error response", log.Data{"status": status}, log.INFO)
 		rI.intercepted = true
-		if status == 500 {
-			rI.renderErrorPage(500, "Internal server error", "<p>We're currently experiencing some technical difficulties. You could try <a href='"+rI.req.Host+url.QueryEscape(rI.req.URL.Path)+"'>refreshing the page or trying again later.</a> </p>")
-		} else if status == 404 {
+		if status == 404 {
 			rI.renderErrorPage(404, "404 - The webpage you are requesting does not exist on the site", `<p> The page may have been moved, updated or deleted or you may have typed the web address incorrectly, please check the url and spelling. Alternatively, please try the search, or return to the <a href="/" title="Our homepage" target="_self">homepage</a> and use the sitemap.</p>`)
+			return
 		} else if status == 401 {
 			rI.renderErrorPage(401, "401 - You do not have permission to view this web page", `<p>This page may exist, but you do not currently have permission to view it. If you believe this to be incorrect please contact a system administrator.</p>`)
-		} else {
-			rI.renderErrorPage(503, "Service temporarily unavailable", `<p>The service is temporarily unavailable, please check our <a href="https://twitter.com/onsdigital">twitter</a> feed for updates.</p>`)
+			return
 		}
-		return
 	}
 	rI.writeHeaders()
 	rI.ResponseWriter.WriteHeader(status)

--- a/middleware/serverError/handler.go
+++ b/middleware/serverError/handler.go
@@ -1,0 +1,146 @@
+package serverError
+
+// This whole package and process needs a refactor. Re-added file - take very little responsibility for anything in here
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/ONSdigital/dp-frontend-router/config"
+	"github.com/ONSdigital/dp-frontend-router/lang"
+	"github.com/ONSdigital/log.go/log"
+)
+
+type responseInterceptor struct {
+	http.ResponseWriter
+	req            *http.Request
+	intercepted    bool
+	headersWritten bool
+	headerCache    http.Header
+}
+
+func (rI *responseInterceptor) WriteHeader(status int) {
+	if status >= 400 {
+		log.Event(rI.req.Context(), "Intercepted error response", log.Data{"status": status}, log.INFO)
+		rI.intercepted = true
+		if status == 500 {
+			rI.renderErrorPage(500, "Internal server error", "<p>We're currently experiencing some technical difficulties. You could try <a href='"+rI.req.Host+url.QueryEscape(rI.req.URL.Path)+"'>refreshing the page or trying again later.</a> </p>")
+		} else if status == 404 {
+			rI.renderErrorPage(404, "404 - The webpage you are requesting does not exist on the site", `<p> The page may have been moved, updated or deleted or you may have typed the web address incorrectly, please check the url and spelling. Alternatively, please try the search, or return to the <a href="/" title="Our homepage" target="_self">homepage</a> and use the sitemap.</p>`)
+		} else if status == 401 {
+			rI.renderErrorPage(401, "401 - You do not have permission to view this web page", `<p>This page may exist, but you do not currently have permission to view it. If you believe this to be incorrect please contact a system administrator.</p>`)
+		} else {
+			rI.renderErrorPage(503, "Service temporarily unavailable", `<p>The service is temporarily unavailable, please check our <a href="https://twitter.com/onsdigital">twitter</a> feed for updates.</p>`)
+		}
+		return
+	}
+	rI.writeHeaders()
+	rI.ResponseWriter.WriteHeader(status)
+}
+
+func (rI *responseInterceptor) renderErrorPage(code int, title, description string) {
+	// Attempt to render an error page
+	if err := rI.callRenderer(code, title, description); err != nil {
+		// Calling the renderer failed, render the disaster page
+		if err != nil {
+			rI.writeHeaders()
+			rI.ResponseWriter.WriteHeader(http.StatusInternalServerError)
+			log.Event(rI.req.Context(), "error calling renderer", log.Error(err), log.ERROR)
+			return
+		}
+	}
+}
+
+func (rI *responseInterceptor) callRenderer(code int, title, description string) error {
+	cfg, err := config.Get()
+	if err != nil {
+		return err
+	}
+	data := map[string]interface{}{
+		"error": map[string]interface{}{
+			"title":       title,
+			"description": description,
+		},
+	}
+
+	b, err := json.Marshal(&data)
+	if err != nil {
+		return fmt.Errorf("error marshaling data: %s", err)
+	}
+
+	rendererReq, err := http.NewRequest("POST", cfg.RendererURL+"/error", bytes.NewReader(b))
+	if err != nil {
+		err = fmt.Errorf("error creating request: %s", err)
+		return err
+	}
+
+	// FIXME there's other headers we want
+	rendererReq.Header.Set("Accept-Language", string(lang.Get(rI.req)))
+	rendererReq.Header.Set("X-Request-Id", rI.req.Header.Get("X-Request-Id"))
+
+	res, err := http.DefaultClient.Do(rendererReq)
+	if err != nil {
+		return fmt.Errorf("error rendering page: %s", err)
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
+	b, err = ioutil.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response body: %s", err)
+	}
+
+	for hdr, v := range res.Header {
+		for _, v2 := range v {
+			rI.ResponseWriter.Header().Add(hdr, v2)
+		}
+	}
+
+	log.Event(rI.req.Context(), "returning error page", log.INFO)
+	rI.ResponseWriter.WriteHeader(code)
+	rI.ResponseWriter.Write(b)
+
+	return nil
+}
+
+func (rI *responseInterceptor) Write(b []byte) (int, error) {
+	if rI.intercepted {
+		return len(b), nil
+	}
+	rI.writeHeaders()
+	return rI.ResponseWriter.Write(b)
+}
+
+func (rI *responseInterceptor) writeHeaders() {
+	if rI.headersWritten {
+		return
+	}
+
+	// Overwrite the server header
+	rI.headerCache.Set("Server", "dp-frontend-router")
+
+	for k, v := range rI.headerCache {
+		for _, v2 := range v {
+			rI.ResponseWriter.Header().Add(k, v2)
+		}
+	}
+
+	rI.headersWritten = true
+}
+
+func (rI *responseInterceptor) Header() http.Header {
+	return rI.headerCache
+}
+
+func Handler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		h.ServeHTTP(&responseInterceptor{w, req, false, false, make(http.Header)}, req)
+	})
+}


### PR DESCRIPTION
### What

Reintroduced the serverError package into the repo. I was a little too zelus in my removal of rendering in the router in a prior PR.

Note to compare what has actually changed by me and not just been readded compare [https://github.com/ONSdigital/dp-frontend-router/blob/master/middleware/serverError/handler.go](https://github.com/ONSdigital/dp-frontend-router/blob/master/middleware/serverError/handler.go)

A comparison can be seen here: https://www.diffchecker.com/I3vaDbeI

### How to review

⚠️ Please only review what has actually changed in this PR and found on the above diff link. This PR is quite urgent as without it it is blocking quite a large chunk of work from being deployed. There is a lot in the file that shouldn't be the way it is, but this is out of scope for this 'fix'. ⚠️ 

Check that 404 status on requests returns a 404 page. Check for contents of both Babbage and the renderer as the babbage 404 should be thrown out and only using renderer ones. On the 404 pages open the DOM inspector and open the head element and check for the text: `<meta name="ons:service" content="dp-frontend-renderer">` as seen in the below image
<img width="674" alt="Screenshot 2020-02-27 at 11 25 35" src="https://user-images.githubusercontent.com/47502916/75441133-0178af00-5955-11ea-884e-3c08dafebb94.png">

Check that if the renderer is turned off then instead of a 404 page you are given an internal server error.  You will need to check the network request as applications do not handle these but nginx will on the platform side (and if that is down then cloudflare). Instead, locally you would just get a white page or a page that hangs (depending on browser)  with a network response saying 500.

### Who can review

Anyone except me
