### PR TITLE
add centre for equalities and inclusion redirect

### DIFF
--- a/assets/redirects/redirects.csv
+++ b/assets/redirects/redirects.csv
@@ -149,3 +149,4 @@
 /engagement,/aboutus/whatwedo/programmesandprojects/economicstatisticstransformation/engagingwitheconomicstatistics/economicstatisticsevents
 /studycontact,/aboutus/whatwedo/programmesandprojects/studycontact
 /cis,/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/covid19infectionsurveycis
+/aboutus/whatwedo/programmesandprojects/centreforequalitiesandinclusion,/aboutus/whatwedo/programmesandprojects/onscentres/centreforequalitiesandinclusion


### PR DESCRIPTION
### What

The Centre for Equalities and Inclusions section of the site now resides in a different path. This means that the previously used URL now 404s.

This PR adds a redirect from the old URL to the new URL.

### How to review

- Check that the redirect aligns with requirements in the `WHAT` section of the [ticket](https://trello.com/c/OMxQnshZ/128-create-redirect-url-1-2)
- Test locally that the redirect works

### Who can review

Anyone but me
