### PR TITLE
Fix size check against 'ContentTypeByteLimit'

### DIFF
--- a/middleware/allRoutes/handler.go
+++ b/middleware/allRoutes/handler.go
@@ -71,7 +71,7 @@ func Handler(routesHandler map[string]http.Handler, zebedeeClient *client.Client
 				return
 			}
 
-			if len(b) == cfg.ContentTypeByteLimit+1 {
+			if len(b) > cfg.ContentTypeByteLimit {
 				log.Event(req.Context(), "Response exceeds acceptable byte limit for assessing content-type. Falling through to default handling", log.WARN)
 				h.ServeHTTP(w, req)
 				return


### PR DESCRIPTION
Make code do size check and not equality to a 'magic number' so as the code matches the log.Event() message in the next line.
