### PR TITLE
add missing quotation mark to homepage controller URL config entry

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,7 @@ type Config struct {
 	CookiesControllerURL       string        `envconfig:"COOKIES_CONTROLLER_URL"`
 	CookiesRoutesEnabled       bool          `envconfig:"COOKIES_ROUTES_ENABLED"`
 	NewHomepageEnabled         bool          `envconfig:"NEW_HOMEPAGE_ENABLED"`
-	HomepageControllerURL      string        `envconfig:"HOMEPAGE_CONTROLLER_URL`
+	HomepageControllerURL      string        `envconfig:"HOMEPAGE_CONTROLLER_URL"`
 	DatasetRoutesEnabled       bool          `envconfig:"DATASET_ROUTES_ENABLED"`
 	DatasetControllerURL       string        `envconfig:"DATASET_CONTROLLER_URL"`
 	FilterDatasetControllerURL string        `envconfig:"FILTER_DATASET_CONTROLLER_URL"`


### PR DESCRIPTION
### What

Added missing `"` at the end of the `HomepageControllerURL` config property.