### PR TITLE
Limit the request header size.

### DIFF
--- a/main.go
+++ b/main.go
@@ -165,6 +165,7 @@ func main() {
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  120 * time.Second,
+		MaxHeaderBytes: 1024,
 	}
 
 	// Start healthcheck


### PR DESCRIPTION
This needs to be done to stop unnaturally long headers filling log files and causing LARGE memory allocations - that do lead on to other problems.
