### PR TITLE
Feature/add cookies redirect

### DIFF
--- a/assets/redirects/redirects.csv
+++ b/assets/redirects/redirects.csv
@@ -150,3 +150,4 @@
 /studycontact,/aboutus/whatwedo/programmesandprojects/studycontact
 /cis,/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/covid19infectionsurveycis
 /aboutus/whatwedo/programmesandprojects/centreforequalitiesandinclusion,/aboutus/whatwedo/programmesandprojects/onscentres/centreforequalitiesandinclusion
+/help/cookiesandprivacy,/help/cookies

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/pat v1.0.1
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
+	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/justinas/alice v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e h1:0aewS5NT
 github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=


### PR DESCRIPTION
### What

Added a redirect so `/help/cookiesandprivacy` => `/help/cookies` in prep for switching on cookies work on prod

### How to review

Check that the redirect aligns with [ticket requirements](https://trello.com/c/qU48VoGW/237-05-url-redirect-help-cookiesandprivacy-to-help-cookies-1-2)

### Who can review

Anyone but me
