### PR TITLE
feature/add redirect for shapestudy

### DIFF
--- a/assets/redirects/redirects.csv
+++ b/assets/redirects/redirects.csv
@@ -151,3 +151,4 @@
 /cis,/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/covid19infectionsurveycis
 /aboutus/whatwedo/programmesandprojects/centreforequalitiesandinclusion,/aboutus/whatwedo/programmesandprojects/onscentres/centreforequalitiesandinclusion
 /help/cookiesandprivacy,/help/cookies
+/shapestudy,/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/findingyourstudy/shapetomorrow


### PR DESCRIPTION
### What

Added a redirect: `/shapestudy` => `/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/findingyourstudy/shapetomorrow`

### How to review

Check that entering `/shapestudy` redirects you to the longer URL

### Who can review

Anyone
