### PR TITLE
Fix - Set html language for error pages 

### DIFF
--- a/middleware/serverError/handler.go
+++ b/middleware/serverError/handler.go
@@ -57,6 +57,10 @@ func (rI *responseInterceptor) callRenderer(code int, title, description string)
 		return err
 	}
 	preferencesCookie := cookies.GetCookiePreferences(rI.req)
+	language, err := cookies.GetLang(rI.req)
+	if err != nil {
+		language = "en"
+	}
 	data := map[string]interface{}{
 		"error": map[string]interface{}{
 			"title":       title,
@@ -64,6 +68,7 @@ func (rI *responseInterceptor) callRenderer(code int, title, description string)
 		},
 		"cookies_preferences_set": preferencesCookie.IsPreferenceSet,
 		"cookies_policy":          preferencesCookie.Policy,
+		"language":                language,
 	}
 
 	b, err := json.Marshal(&data)


### PR DESCRIPTION
### What
Set the html language for error pages based on the language cookie defaulting to `en`

### How to review
1. Load a 404 page and see there is no html language
1. Switch to this branch and see the html lang and xml:lang attributes are set
1. Add a `lang` cookie value of `cy`.
1. See that the html lang attributes reflect this value

### Who can review
Anyone but me