### PR TITLE
Add /householdstudies redirect

### DIFF
--- a/assets/redirects/redirects.csv
+++ b/assets/redirects/redirects.csv
@@ -152,3 +152,4 @@
 /aboutus/whatwedo/programmesandprojects/centreforequalitiesandinclusion,/aboutus/whatwedo/programmesandprojects/onscentres/centreforequalitiesandinclusion
 /help/cookiesandprivacy,/help/cookies
 /shapestudy,/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/findingyourstudy/shapetomorrow
+/householdstudies,/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys


### PR DESCRIPTION
### What

Added a redirect - `/householdstudies` => `/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys`

### How to review

Check locally that when you go to the short url, you are redirected to the long one (404 expected as we wouldn't have the page content locally)

### Who can review

Anyone but me
