### PR TITLE
remove reference to sitemap in 404 error msg

### DIFF
--- a/middleware/serverError/handler.go
+++ b/middleware/serverError/handler.go
@@ -27,7 +27,7 @@ func (rI *responseInterceptor) WriteHeader(status int) {
 		log.Event(rI.req.Context(), "Intercepted error response", log.Data{"status": status}, log.INFO)
 		rI.intercepted = true
 		if status == 404 {
-			rI.renderErrorPage(404, "404 - The webpage you are requesting does not exist on the site", `<p> The page may have been moved, updated or deleted or you may have typed the web address incorrectly, please check the url and spelling. Alternatively, please try the search, or return to the <a href="/" title="Our homepage" target="_self">homepage</a> and use the sitemap.</p>`)
+			rI.renderErrorPage(404, "404 - The webpage you are requesting does not exist on the site", `<p> The page may have been moved, updated or deleted or you may have typed the web address incorrectly, please check the url and spelling. Alternatively, please try the search, or return to the <a href="/" title="Our homepage" target="_self">homepage</a>.</p>`)
 			return
 		} else if status == 401 {
 			rI.renderErrorPage(401, "401 - You do not have permission to view this web page", `<p>This page may exist, but you do not currently have permission to view it. If you believe this to be incorrect please contact a system administrator.</p>`)

--- a/middleware/serverError/handler.go
+++ b/middleware/serverError/handler.go
@@ -27,7 +27,7 @@ func (rI *responseInterceptor) WriteHeader(status int) {
 		log.Event(rI.req.Context(), "Intercepted error response", log.Data{"status": status}, log.INFO)
 		rI.intercepted = true
 		if status == 404 {
-			rI.renderErrorPage(404, "404 - The webpage you are requesting does not exist on the site", `<p> The page may have been moved, updated or deleted or you may have typed the web address incorrectly, please check the url and spelling. Alternatively, please try the search, or return to the <a href="/" title="Our homepage" target="_self">homepage</a>.</p>`)
+			rI.renderErrorPage(404, "404 - The webpage you are requesting does not exist on the site", `<p> The page may have been moved, updated or deleted or you may have typed the web address incorrectly, please check the url and spelling. Alternatively, please try the <a href="#nav-search">search</a>, or return to the <a href="/" title="Our homepage" target="_self">homepage</a>.</p>`)
 			return
 		} else if status == 401 {
 			rI.renderErrorPage(401, "401 - You do not have permission to view this web page", `<p>This page may exist, but you do not currently have permission to view it. If you believe this to be incorrect please contact a system administrator.</p>`)


### PR DESCRIPTION
### What

Hotfix to be implemented so that 404 error page can display a warning for users that some datasets will have been moved owing to the Neptune migration.

This is specifically a small change to the 404 error msg that removes the copy to the sitemap, as per the prototype, because there is no reference to the sitemap on the homepage

### How to review

- Check in conjunction with [this renderer PR](https://github.com/ONSdigital/dp-frontend-renderer/pull/532)
- Go to a page locally that'll give you a 404 - check that the copy and design matches [this prototype](https://deploy-preview-6--dp-prototypes.netlify.app/prototypes/status-banner/404-page) 

### Who can review

Anyone
