### PR TITLE
Release/1.25.0

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,6 @@ type Config struct {
 	BabbageURL                 string        `envconfig:"BABBAGE_URL"`
 	RendererURL                string        `envconfig:"RENDERER_URL"`
 	CookiesControllerURL       string        `envconfig:"COOKIES_CONTROLLER_URL"`
-	NewHomepageEnabled         bool          `envconfig:"NEW_HOMEPAGE_ENABLED"`
 	HomepageControllerURL      string        `envconfig:"HOMEPAGE_CONTROLLER_URL"`
 	DatasetControllerURL       string        `envconfig:"DATASET_CONTROLLER_URL"`
 	FilterDatasetControllerURL string        `envconfig:"FILTER_DATASET_CONTROLLER_URL"`
@@ -46,7 +45,6 @@ func Get() (*Config, error) {
 		BabbageURL:                 "http://localhost:8080",
 		RendererURL:                "http://localhost:20010",
 		CookiesControllerURL:       "http://localhost:24100",
-		NewHomepageEnabled:         false,
 		HomepageControllerURL:      "http://localhost:24400",
 		DatasetControllerURL:       "http://localhost:20200",
 		FilterDatasetControllerURL: "http://localhost:20001",

--- a/main.go
+++ b/main.go
@@ -165,14 +165,11 @@ func main() {
 		router.Handle("/geography{uri:.*}", createReverseProxy("geography", geographyControllerURL))
 	}
 
-	if cfg.NewHomepageEnabled {
-		router.Handle("/", createReverseProxy("homepage", homepageControllerURL))
-	}
-
 	if cfg.SearchRoutesEnabled {
 		router.Handle("/search", createReverseProxy("search", searchControllerURL))
 	}
 
+	router.Handle("/", createReverseProxy("homepage", homepageControllerURL))
 	router.Handle("/{uri:.*}", reverseProxy)
 
 	log.Event(nil, "Starting server", log.INFO, log.Data{"config": cfg})


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Remove the `NewHomepageEnabled` flag as the old homepage is no longer in `babbage` as it was removed. Therefore, there only exists the new homepage in which a feature flag is no longer needed. Also, this helps developers as well in which they do not need to set this feature flag to `true` whenever they try to retrieve the homepage when running services locally. 

### How to review
**Describe the steps required to test the changes.**
Check if the code changes make sense (very small change). This was already reviewed in https://github.com/ONSdigital/dp-frontend-router/pull/245

### Who can review
**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes