### PR TITLE
Fix nancy audit failure by using forked jwt-go lib

### DIFF
--- a/analytics/service.go
+++ b/analytics/service.go
@@ -56,8 +56,6 @@ func (s *ServiceImpl) CaptureAnalyticsData(r *http.Request) (string, error) {
 		return "", errors.Wrap(err, "Invalid redirect data")
 	}
 
-	log.Event(r.Context(), "jwt token", log.INFO, log.Data{"token": token})
-
 	var url, term, listType, gaID, gID string
 	var pageIndex, linkIndex, pageSize float64
 

--- a/analytics/service.go
+++ b/analytics/service.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/ONSdigital/log.go/log"
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/form3tech-oss/jwt-go"
 )
 
 const pageIndexParam = "pageIndex"
@@ -16,7 +16,6 @@ const linkIndexParam = "linkIndex"
 const urlParam = "url"
 const termParam = "term"
 const searchTypeParam = "type"
-const timestampKey = "timestamp"
 const gaIDParam = "ga"
 const gIDParam = "gid"
 

--- a/analytics/service_test.go
+++ b/analytics/service_test.go
@@ -303,9 +303,9 @@ func Test_extractIntParam(t *testing.T) {
 	})
 }
 
-// The following code is borrowed from v3.2.2 of alternative library:
+// The following code is borrowed from v3.2.2 of library:
 // github.com/form3tech-oss/jwt-go
-// and tweaked a little to demonstrate issues with original library:
+// and tweaked a little to demonstrate issues with the previously used library:
 // github.com/dgrijalva/jwt-go
 // BUT the code won't work with v4 of original library
 

--- a/analytics/service_test.go
+++ b/analytics/service_test.go
@@ -1,11 +1,19 @@
 package analytics
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
+	jwt "github.com/form3tech-oss/jwt-go"
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+// For HMAC signing method, the key can be any []byte. It is recommended to generate
+// a key using crypto/rand or something equivalent. You need the same key for signing
+// and validating.
+var hmacSampleSecret []byte = []byte("secret")
+var hmacBadSampleSecret []byte = []byte("bad")
 
 func Test_extractIntParam(t *testing.T) {
 	s := &ServiceImpl{
@@ -17,6 +25,25 @@ func Test_extractIntParam(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		q := r.URL.Query()
+		// using: https://jwt.io/#debugger-io
+		// the q.Set() below has:
+		// HEADER:ALGORITHM & TOKEN TYPE
+		/*
+			{
+			  "alg": "HS256"
+			}
+		*/
+		// PAYLOAD: DATA
+		/*
+			{
+			  "index": 1,
+			  "pageSize": 10,
+			  "term": "Integrated",
+			  "page": 1,
+			  "uri": "/peoplepopulationandcommunity/housing/bulletins/integratedhouseholdsurveyexperimentalstatistics/2014-10-07",
+			  "listType": "search"
+			}
+		*/
 		q.Set(":data", "eyJhbGciOiJIUzI1NiJ9.eyJpbmRleCI6MSwicGFnZVNpemUiOjEwLCJ0ZXJtIjoiSW50ZWdyYXRlZCIsInBhZ2UiOjEsInVyaSI6Ii9wZW9wbGVwb3B1bGF0aW9uYW5kY29tbXVuaXR5L2hvdXNpbmcvYnVsbGV0aW5zL2ludGVncmF0ZWRob3VzZWhvbGRzdXJ2ZXlleHBlcmltZW50YWxzdGF0aXN0aWNzLzIwMTQtMTAtMDciLCJsaXN0VHlwZSI6InNlYXJjaCJ9.MQnW73Zca_7DZbYXjQC9FMIbCiJjNe--AKcCpLU2azw")
 		r.URL.RawQuery = q.Encode()
 
@@ -24,4 +51,326 @@ func Test_extractIntParam(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(url, ShouldEqual, "/peoplepopulationandcommunity/housing/bulletins/integratedhouseholdsurveyexperimentalstatistics/2014-10-07")
 	})
+
+	Convey("Given a valid redirect URL, 2nd version", t, func() {
+		r, err := http.NewRequest("GET", "/redir/{:data}", nil)
+		So(r, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		q := r.URL.Query()
+
+		// Create a new token object, specifying signing method and the claims
+		// you would like it to contain.
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"index":    1,
+			"pageSize": 10,
+			"term":     "Integrated",
+			"page":     1,
+			"uri":      "/peoplepopulationandcommunity/housing/bulletins/integratedhouseholdsurveyexperimentalstatistics/2014-10-07",
+			"listType": "search",
+		})
+
+		// Sign and get the complete encoded token as a string using the secret
+		tokenString, err := token.SignedString(hmacSampleSecret)
+		So(err, ShouldBeNil)
+
+		q.Set(":data", tokenString)
+		r.URL.RawQuery = q.Encode()
+
+		url, err := s.CaptureAnalyticsData(r)
+		So(err, ShouldBeNil)
+		So(url, ShouldEqual, "/peoplepopulationandcommunity/housing/bulletins/integratedhouseholdsurveyexperimentalstatistics/2014-10-07")
+	})
+
+	Convey("Given a valid redirect URL, but payload has no uri", t, func() {
+		r, err := http.NewRequest("GET", "/redir/{:data}", nil)
+		So(r, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		q := r.URL.Query()
+
+		// Create a new token object, specifying signing method and the claims
+		// you would like it to contain.
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"index":    1,
+			"pageSize": 10,
+			"term":     "Integrated",
+			"page":     1,
+			"listType": "search",
+		})
+
+		// Sign and get the complete encoded token as a string using the secret
+		tokenString, err := token.SignedString(hmacSampleSecret)
+		So(err, ShouldBeNil)
+
+		q.Set(":data", tokenString)
+		r.URL.RawQuery = q.Encode()
+
+		_, err = s.CaptureAnalyticsData(r)
+		So(err, ShouldNotBeNil)
+		es := fmt.Sprintf("%s", err)
+		So(es, ShouldEqual, "url is a mandatory parameter")
+	})
+
+	Convey("Given a valid redirect URL, with bad secret", t, func() {
+		r, err := http.NewRequest("GET", "/redir/{:data}", nil)
+		So(r, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		q := r.URL.Query()
+
+		// Create a new token object, specifying signing method and the claims
+		// you would like it to contain.
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"index": 1,
+		})
+
+		// Sign and get the complete encoded token as a string using the BAD secret
+		tokenString, err := token.SignedString(hmacBadSampleSecret)
+		So(err, ShouldBeNil)
+
+		q.Set(":data", tokenString)
+		r.URL.RawQuery = q.Encode()
+
+		_, err = s.CaptureAnalyticsData(r)
+		So(err, ShouldNotBeNil)
+		es := fmt.Sprintf("%s", err)
+		// The following contains two errors, ONS's + lib error
+		// We can only look for ONS's error, as the library error might change
+		So(es, ShouldContainSubstring, "Invalid redirect data")
+	})
+
+	Convey("Given a valid redirect URL, and nil aud", t, func() {
+		r, err := http.NewRequest("GET", "/redir/{:data}", nil)
+		So(r, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		q := r.URL.Query()
+
+		// Create a new token object, specifying signing method and the claims
+		// you would like it to contain.
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"index": 1,
+			"aud":   nil,
+			"uri":   "/peoplepopulationandcommunity",
+		})
+
+		// Sign and get the complete encoded token as a string using the secret
+		tokenString, err := token.SignedString(hmacSampleSecret)
+		So(err, ShouldBeNil)
+
+		q.Set(":data", tokenString)
+		r.URL.RawQuery = q.Encode()
+
+		url, err := s.CaptureAnalyticsData(r)
+		So(err, ShouldBeNil)
+		So(url, ShouldEqual, "/peoplepopulationandcommunity")
+	})
+
+	Convey("Given a valid redirect URL, and Empty aud", t, func() {
+		r, err := http.NewRequest("GET", "/redir/{:data}", nil)
+		So(r, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		q := r.URL.Query()
+
+		// Create a new token object, specifying signing method and the claims
+		// you would like it to contain.
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"index": 1,
+			"aud":   "",
+			"uri":   "/peoplepopulationandcommunity",
+		})
+
+		// Sign and get the complete encoded token as a string using the secret
+		tokenString, err := token.SignedString(hmacSampleSecret)
+		So(err, ShouldBeNil)
+
+		q.Set(":data", tokenString)
+		r.URL.RawQuery = q.Encode()
+
+		url, err := s.CaptureAnalyticsData(r)
+		So(err, ShouldBeNil)
+		So(url, ShouldEqual, "/peoplepopulationandcommunity")
+	})
+
+	Convey("Given a valid redirect URL, and aud has a string", t, func() {
+		r, err := http.NewRequest("GET", "/redir/{:data}", nil)
+		So(r, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		q := r.URL.Query()
+
+		// Create a new token object, specifying signing method and the claims
+		// you would like it to contain.
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"index": 1,
+			"aud":   "hello",
+			"uri":   "/peoplepopulationandcommunity",
+		})
+
+		// Sign and get the complete encoded token as a string using the secret
+		tokenString, err := token.SignedString(hmacSampleSecret)
+		So(err, ShouldBeNil)
+
+		q.Set(":data", tokenString)
+		r.URL.RawQuery = q.Encode()
+
+		url, err := s.CaptureAnalyticsData(r)
+		So(err, ShouldBeNil)
+		So(url, ShouldEqual, "/peoplepopulationandcommunity")
+	})
+
+	Convey("Given a valid redirect URL, and aud has no elements in []string", t, func() {
+		r, err := http.NewRequest("GET", "/redir/{:data}", nil)
+		So(r, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		q := r.URL.Query()
+
+		// Create a new token object, specifying signing method and the claims
+		// you would like it to contain.
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"index": 1,
+			"aud":   []string{},
+			"uri":   "/peoplepopulationandcommunity",
+		})
+
+		// Sign and get the complete encoded token as a string using the secret
+		tokenString, err := token.SignedString(hmacSampleSecret)
+		So(err, ShouldBeNil)
+
+		q.Set(":data", tokenString)
+		r.URL.RawQuery = q.Encode()
+
+		url, err := s.CaptureAnalyticsData(r)
+		So(err, ShouldBeNil)
+		So(url, ShouldEqual, "/peoplepopulationandcommunity")
+	})
+
+	Convey("Given a valid redirect URL, and aud has one element in []string", t, func() {
+		r, err := http.NewRequest("GET", "/redir/{:data}", nil)
+		So(r, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		q := r.URL.Query()
+
+		// Create a new token object, specifying signing method and the claims
+		// you would like it to contain.
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"index": 1,
+			"aud":   []string{"hello2"},
+			"uri":   "/peoplepopulationandcommunity",
+		})
+
+		// Sign and get the complete encoded token as a string using the secret
+		tokenString, err := token.SignedString(hmacSampleSecret)
+		So(err, ShouldBeNil)
+
+		q.Set(":data", tokenString)
+		r.URL.RawQuery = q.Encode()
+
+		url, err := s.CaptureAnalyticsData(r)
+		So(err, ShouldBeNil)
+		So(url, ShouldEqual, "/peoplepopulationandcommunity")
+	})
+
+	Convey("Given a valid redirect URL, and aud has two elements in []string", t, func() {
+		r, err := http.NewRequest("GET", "/redir/{:data}", nil)
+		So(r, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		q := r.URL.Query()
+
+		// Create a new token object, specifying signing method and the claims
+		// you would like it to contain.
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"index": 1,
+			"aud":   []string{"hello3", "hello4"},
+			"uri":   "/peoplepopulationandcommunity",
+		})
+
+		// Sign and get the complete encoded token as a string using the secret
+		tokenString, err := token.SignedString(hmacSampleSecret)
+		So(err, ShouldBeNil)
+
+		q.Set(":data", tokenString)
+		r.URL.RawQuery = q.Encode()
+
+		url, err := s.CaptureAnalyticsData(r)
+		So(err, ShouldBeNil)
+		So(url, ShouldEqual, "/peoplepopulationandcommunity")
+	})
+}
+
+// The following code is borrowed from v3.2.2 of alternative library:
+// github.com/form3tech-oss/jwt-go
+// and tweaked a little to demonstrate issues with original library:
+// github.com/dgrijalva/jwt-go
+// BUT the code won't work with v4 of original library
+
+func Test_mapClaims_list_aud(t *testing.T) {
+	mapClaims := jwt.MapClaims{
+		"aud": []string{"foo"},
+	}
+	want := true
+	got := mapClaims.VerifyAudience("foo", true)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+func Test_mapClaims_string_aud(t *testing.T) {
+	mapClaims := jwt.MapClaims{
+		"aud": "foo",
+	}
+	want := true
+	got := mapClaims.VerifyAudience("foo", true)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+
+func Test_mapClaims_list_aud_no_match(t *testing.T) {
+	mapClaims := jwt.MapClaims{
+		"aud": []string{"bar"},
+	}
+	want := false
+	got := mapClaims.VerifyAudience("foo", true)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+func Test_mapClaims_string_aud_fail(t *testing.T) {
+	mapClaims := jwt.MapClaims{
+		"aud": "bar",
+	}
+	want := false
+	got := mapClaims.VerifyAudience("foo", true)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+
+func Test_mapClaims_string_aud_no_claim(t *testing.T) {
+	mapClaims := jwt.MapClaims{}
+	want := false
+	got := mapClaims.VerifyAudience("foo", true)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+
+func Test_mapClaims_string_aud_no_claim_not_required(t *testing.T) {
+	mapClaims := jwt.MapClaims{}
+	want := false
+	got := mapClaims.VerifyAudience("foo", false)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/aws/aws-sdk-go-v2/config v1.1.5
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.3.1
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fatih/color v1.10.0 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/pat v1.0.1
 	github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,14 +45,14 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.2.2/go.mod h1:ssRzzJ2RZOVuKj2Vx1YE7y
 github.com/aws/smithy-go v1.3.1 h1:xJFO4pK0y9J8fCl34uGsSJX5KNnGbdARDlA5BPhXnwE=
 github.com/aws/smithy-go v1.3.1/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmAp6Sws4L7+Q/OokbWDAK1ibXYhB3PXFP1kol5hPg=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
+github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/go-avro/avro v0.0.0-20171219232920-444163702c11/go.mod h1:kxj6THYP0dmFPk4Z+bijIAhJoGgeBfyOKXMduhvdJPA=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func healthcheckHandler(hc func(w http.ResponseWriter, req *http.Request)) func(
 	}
 }
 
-//abHandler ... percentA is the percentage of request that handler 'a' is used
+// abHandler ... percentA is the percentage of request that handler 'a' is used
 //
 // FIXME this isn't used anymore, it could be removed, but seems like it might be useful?
 func abHandler(a, b http.Handler, percentA int) http.Handler {

--- a/middleware/allRoutes/handler.go
+++ b/middleware/allRoutes/handler.go
@@ -3,18 +3,19 @@ package allRoutes
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"path/filepath"
+
 	client "github.com/ONSdigital/dp-api-clients-go/zebedee"
 	"github.com/ONSdigital/dp-frontend-router/config"
 	dprequest "github.com/ONSdigital/dp-net/request"
 	"github.com/ONSdigital/log.go/log"
-	"net/http"
-	"path/filepath"
 )
 
 // HeaderOnsPageType is the header name that defines the handler that will be used by the Middleware
 const HeaderOnsPageType = "ONS-Page-Type"
 
-//Handler implements the middleware for dp-frontend-router. It sets the locale code, obtains the necessary cookies for the request path and access_token,
+// Handler implements the middleware for dp-frontend-router. It sets the locale code, obtains the necessary cookies for the request path and access_token,
 // authenticates with Zebedee if required,  and obtains the "ONS-Page-Type" header to use the handler for the page type, if present.
 func Handler(routesHandler map[string]http.Handler, zebedeeClient *client.Client, cfg *config.Config) func(h http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
@@ -39,7 +40,7 @@ func Handler(routesHandler map[string]http.Handler, zebedeeClient *client.Client
 				contentPath += "?uri=" + path
 			}
 
-			//FIXME We should be doing a HEAD request but Restolino doesn't allow it - either wait for the
+			// FIXME We should be doing a HEAD request but Restolino doesn't allow it - either wait for the
 			// new Content API (https://github.com/ONSdigital/dp-content-api) to be in prod or update Restolino
 			/// Update: Is this still needed when using the Zebedee client?
 

--- a/middleware/redirects/redirects.go
+++ b/middleware/redirects/redirects.go
@@ -68,7 +68,7 @@ func Init(asset func(name string) ([]byte, error)) {
 	}
 }
 
-//Handler ...
+// Handler ...
 func Handler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 

--- a/middleware/redirects/redirects_test.go
+++ b/middleware/redirects/redirects_test.go
@@ -118,7 +118,7 @@ func BenchmarkWithoutRedirectMiddleware(b *testing.B) {
 	middleware := []alice.Constructor{
 		dprequest.HandlerRequestID(16),
 		log.Middleware,
-		//securityHandler,
+		// securityHandler,
 	}
 	alice := alice.New(middleware...).Then(router)
 	router.HandleFunc("/{uri:.*}", func(w http.ResponseWriter, req *http.Request) {})
@@ -135,7 +135,7 @@ func BenchmarkWithoutRedirects(b *testing.B) {
 	middleware := []alice.Constructor{
 		dprequest.HandlerRequestID(16),
 		log.Middleware,
-		//securityHandler,
+		// securityHandler,
 		Handler,
 	}
 	alice := alice.New(middleware...).Then(router)
@@ -158,7 +158,7 @@ func BenchmarkWith100Redirects(b *testing.B) {
 	middleware := []alice.Constructor{
 		dprequest.HandlerRequestID(16),
 		log.Middleware,
-		//securityHandler,
+		// securityHandler,
 		Handler,
 	}
 	alice := alice.New(middleware...).Then(router)
@@ -181,7 +181,7 @@ func BenchmarkWith10000Redirects(b *testing.B) {
 	middleware := []alice.Constructor{
 		dprequest.HandlerRequestID(16),
 		log.Middleware,
-		//securityHandler,
+		// securityHandler,
 		Handler,
 	}
 	alice := alice.New(middleware...).Then(router)
@@ -204,7 +204,7 @@ func BenchmarkWith1000000Redirects(b *testing.B) {
 	middleware := []alice.Constructor{
 		dprequest.HandlerRequestID(16),
 		log.Middleware,
-		//securityHandler,
+		// securityHandler,
 		Handler,
 	}
 	alice := alice.New(middleware...).Then(router)


### PR DESCRIPTION
### What
1. Use forked version of jwt-go lib that fixes the audit that nancy reports.
2. Add test code to show new lib fixes the problem, and if the test code is run against original library it shows it failing.
3. Code clean up of a few linter issues.

### How to review

run:
make audit
make test

inspect test code

### Who can review

Anyone.
