### PR TITLE
Send /data and /latest requests directly to Babbage

### DIFF
--- a/router/matcher.go
+++ b/router/matcher.go
@@ -23,6 +23,11 @@ var knownBabbageEndpoints = []string{
 	"/hash",
 }
 
+var knownBabbageEndpointSuffixes = []string{
+	"/data",
+	"/latest",
+}
+
 var knownBabbageEndpointPrefixes = []string{
 	"/visualisations/",
 	"/ons/",
@@ -37,6 +42,11 @@ func IsKnownBabbageEndpoint(path string) bool {
 	}
 	for _, endpoint := range knownBabbageEndpointPrefixes {
 		if strings.HasPrefix(path, endpoint) {
+			return true
+		}
+	}
+	for _, endpoint := range knownBabbageEndpointSuffixes {
+		if strings.HasSuffix(path, endpoint) {
 			return true
 		}
 	}

--- a/router/matcher_test.go
+++ b/router/matcher_test.go
@@ -43,6 +43,8 @@ func TestIsKnownBabbageEndpoint(t *testing.T) {
 				So(router.IsKnownBabbageEndpoint("/file"), ShouldBeTrue)
 				So(router.IsKnownBabbageEndpoint("/ons/some/more/url"), ShouldBeTrue)
 				So(router.IsKnownBabbageEndpoint("/timeseriestool"), ShouldBeTrue)
+				So(router.IsKnownBabbageEndpoint("/economy/environmentalaccounts/bulletins/ukenvironmentalaccounts/latest"), ShouldBeTrue)
+				So(router.IsKnownBabbageEndpoint("/economy/environmentalaccounts/bulletins/ukenvironmentalaccounts/2020/data"), ShouldBeTrue)
 			})
 		})
 	})

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -413,5 +413,44 @@ func TestRouter(t *testing.T) {
 				So(babbageHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
 			})
 		})
+
+		Convey("When a /data request is made", func() {
+
+			url := "/somepage/data"
+			req := httptest.NewRequest("GET", url, nil)
+			res := httptest.NewRecorder()
+
+			router := router.New(config)
+			router.ServeHTTP(res, req)
+
+			Convey("Then a request is not sent to Zebedee to check the page type", func() {
+				So(len(zebedeeClient.GetWithHeadersCalls()), ShouldEqual, 0)
+			})
+
+			Convey("Then the request is sent to Babbage", func() {
+				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(babbageHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
+			})
+		})
+
+		Convey("When a /latest request is made", func() {
+
+			url := "/economy/environmentalaccounts/bulletins/ukenvironmentalaccounts/latest"
+			req := httptest.NewRequest("GET", url, nil)
+			res := httptest.NewRecorder()
+
+			router := router.New(config)
+			router.ServeHTTP(res, req)
+
+			Convey("Then a request is not sent to Zebedee to check the page type", func() {
+				So(len(zebedeeClient.GetWithHeadersCalls()), ShouldEqual, 0)
+			})
+
+			Convey("Then the request is sent to Babbage", func() {
+				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(babbageHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
+			})
+		})
+
 	})
 }


### PR DESCRIPTION
### What
Send /data and /latest requests directly to babbage

Instead of letting /data and /latest requests into the allRoutesHandler, send them directly to Babbage. The allRoutesHandler makes a request to Zebedee to try and determine the page type. Requests to /data will not be recognised by Zebedee. Requests to /latest are only supported by the page types bulletin, article, and compendium. Only dataset page types are rerouted by the allRoutesHandler, it's more optimal to send /latest requests directly to Babbage.

### How to review

Review changes / check I haven't broken anything

### Who can review
Anyone
