### PR TITLE
Feature/area profile routes

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.17.1
+    tag: 1.17.3
 
 inputs:
   - name: dp-frontend-router

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.17.1
+    tag: 1.17.3
 
 inputs:
   - name: dp-frontend-router

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,8 @@ type Config struct {
 	SearchRoutesEnabled                 bool          `envconfig:"SEARCH_ROUTES_ENABLED"`
 	APIRouterURL                        string        `envconfig:"API_ROUTER_URL"`
 	DownloaderURL                       string        `envconfig:"DOWNLOADER_URL"`
+	AreaProfilesControllerURL           string        `envconfig:"AREA_PROFILE_CONTROLLER_URL"`
+	AreaProfilesRoutesEnabled           bool          `envconfig:"AREA_PROFILE_ROUTES_ENABLED"`
 	PatternLibraryAssetsPath            string        `envconfig:"PATTERN_LIBRARY_ASSETS_PATH"`
 	SiteDomain                          string        `envconfig:"SITE_DOMAIN"`
 	RedirectSecret                      string        `envconfig:"REDIRECT_SECRET" json:"-"`
@@ -59,6 +61,8 @@ func Get() (*Config, error) {
 		SearchRoutesEnabled:                 false,
 		APIRouterURL:                        "http://localhost:23200/v1",
 		DownloaderURL:                       "http://localhost:23400",
+		AreaProfilesControllerURL:           "http://localhost:26600",
+		AreaProfilesRoutesEnabled:           false,
 		PatternLibraryAssetsPath:            "https://cdn.ons.gov.uk/sixteens/f816ac8",
 		SiteDomain:                          "ons.gov.uk",
 		RedirectSecret:                      "secret",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,6 +32,8 @@ func TestSpec(t *testing.T) {
 				So(cfg.SearchRoutesEnabled, ShouldEqual, false)
 				So(cfg.APIRouterURL, ShouldEqual, "http://localhost:23200/v1")
 				So(cfg.DownloaderURL, ShouldEqual, "http://localhost:23400")
+				So(cfg.AreaProfilesControllerURL, ShouldEqual, "http://localhost:26600")
+				So(cfg.AreaProfilesRoutesEnabled, ShouldEqual, false)
 				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "https://cdn.ons.gov.uk/sixteens/f816ac8")
 				So(cfg.SiteDomain, ShouldEqual, "ons.gov.uk")
 				So(cfg.RedirectSecret, ShouldEqual, "secret")

--- a/go.mod
+++ b/go.mod
@@ -12,15 +12,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.8.2
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.9.1
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
+	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/pat v1.0.1
+	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/justinas/alice v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.6.4
-)
-
-require (
-	github.com/gorilla/context v1.1.1 // indirect
-	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,4 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 )
 
-require (
-	github.com/gorilla/context v1.1.1 // indirect
-	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
-)
+require github.com/gorilla/context v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,12 +12,32 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.8.2
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.9.1
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
-	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/pat v1.0.1
-	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/justinas/alice v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.6.4
+)
+
+require (
+	github.com/aws/aws-sdk-go-v2 v1.9.1 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.4.2 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.5.1 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.2.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.4.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.7.1 // indirect
+	github.com/aws/smithy-go v1.8.0 // indirect
+	github.com/fatih/color v1.12.0 // indirect
+	github.com/gopherjs/gopherjs v0.0.0-20210918183006-daae65060a40 // indirect
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 // indirect
+	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.13 // indirect
+	github.com/smartystreets/assertions v1.2.0 // indirect
+	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
+	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -21,23 +21,6 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.9.1 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.4.2 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.5.1 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/ini v1.2.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.1 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sso v1.4.1 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.7.1 // indirect
-	github.com/aws/smithy-go v1.8.0 // indirect
-	github.com/fatih/color v1.12.0 // indirect
-	github.com/gopherjs/gopherjs v0.0.0-20210918183006-daae65060a40 // indirect
 	github.com/gorilla/context v1.1.1 // indirect
-	github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 // indirect
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
-	github.com/jtolds/gls v4.20.0+incompatible // indirect
-	github.com/mattn/go-colorable v0.1.8 // indirect
-	github.com/mattn/go-isatty v0.0.13 // indirect
-	github.com/smartystreets/assertions v1.2.0 // indirect
-	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
-	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -20,4 +20,7 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 )
 
-require github.com/gorilla/context v1.1.1 // indirect
+require (
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,6 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-cookies v0.3.2 h1:xNjMXd1upjigCweTnuiW098Cn9ycmrC6li4zXBbRSt0=
-github.com/ONSdigital/dp-cookies v0.3.2/go.mod h1:qyvkAXoVLMNU9Xf1U5zFGRnuWyLxQ/mHloXUXyzcgb8=
 github.com/ONSdigital/dp-cookies v0.3.3 h1:KXX4swf+OnljIYbsTYICIBjuRJoxQukGWKBTvBaISlA=
 github.com/ONSdigital/dp-cookies v0.3.3/go.mod h1:qyvkAXoVLMNU9Xf1U5zFGRnuWyLxQ/mHloXUXyzcgb8=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
@@ -237,8 +235,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
-github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=

--- a/main.go
+++ b/main.go
@@ -100,6 +100,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	areaProfileControllerURL, err := url.Parse(cfg.AreaProfilesControllerURL)
+	if err != nil {
+		log.Fatal(ctx, "configuration value is invalid", err, log.Data{"config_name": "AreaProfileControllerURL", "value": cfg.AreaProfilesControllerURL})
+		os.Exit(1)
+	}
+
 	enableSearchABTest := config.IsEnableSearchABTest(*cfg)
 
 	redirects.Init(assets.Asset)
@@ -138,9 +144,15 @@ func main() {
 	searchHandler := createReverseProxy("search", searchControllerURL)
 	homepageHandler := createReverseProxy("homepage", homepageControllerURL)
 	babbageHandler := createReverseProxy("babbage", babbageURL)
+	var areaProfileHandler http.Handler
+	if cfg.AreaProfilesRoutesEnabled {
+		areaProfileHandler = createReverseProxy("areas", areaProfileControllerURL)
+	}
 
 	routerConfig := router.Config{
 		AnalyticsHandler:       analyticsHandler,
+		AreaProfileEnabled:     cfg.AreaProfilesRoutesEnabled,
+		AreaProfileHandler:     areaProfileHandler,
 		DownloadHandler:        downloadHandler,
 		CookieHandler:          cookieHandler,
 		DatasetHandler:         datasetHandler,

--- a/main.go
+++ b/main.go
@@ -140,13 +140,15 @@ func main() {
 	datasetHandler := createReverseProxy("datasets", datasetControllerURL)
 	filterHandler := createReverseProxy("filters", filterDatasetControllerURL)
 	feedbackHandler := createReverseProxy("feedback", feedbackControllerURL)
-	geographyHandler := createReverseProxy("geography", geographyControllerURL)
 	searchHandler := createReverseProxy("search", searchControllerURL)
 	homepageHandler := createReverseProxy("homepage", homepageControllerURL)
 	babbageHandler := createReverseProxy("babbage", babbageURL)
-	var areaProfileHandler http.Handler
+	areaProfileHandler := createReverseProxy("areas", areaProfileControllerURL)
+	var geographyHandler http.Handler
 	if cfg.AreaProfilesRoutesEnabled {
-		areaProfileHandler = createReverseProxy("areas", areaProfileControllerURL)
+		geographyHandler = redirects.DynamicRedirectHandler("/geography/", "/areas/")
+	} else {
+		geographyHandler = createReverseProxy("geography", geographyControllerURL)
 	}
 
 	routerConfig := router.Config{

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func main() {
 	areaProfileHandler := createReverseProxy("areas", areaProfileControllerURL)
 	var geographyHandler http.Handler
 	if cfg.AreaProfilesRoutesEnabled {
-		geographyHandler = redirects.DynamicRedirectHandler("/geography/", "/areas/")
+		geographyHandler = redirects.DynamicRedirectHandler("/geography", "/areas")
 	} else {
 		geographyHandler = createReverseProxy("geography", geographyControllerURL)
 	}

--- a/middleware/redirects/redirects.go
+++ b/middleware/redirects/redirects.go
@@ -5,7 +5,8 @@ import (
 	"context"
 	"encoding/csv"
 	"net/http"
-	
+	"strings"
+
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
@@ -80,5 +81,15 @@ func Handler(h http.Handler) http.Handler {
 		}
 
 		h.ServeHTTP(w, req)
+	})
+}
+
+// DynamicRedirectHandler redirects requests to the provide 'to' base path
+func DynamicRedirectHandler(redirectFrom, redirectTo string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		redirect := strings.Replace(req.URL.Path, redirectFrom, redirectTo, 1)
+		log.Info(req.Context(), "redirect found", log.Data{"location": redirect}, log.HTTP(req, 0, 0, nil, nil))
+		http.Redirect(w, req, redirect, http.StatusMovedPermanently)
+		return
 	})
 }

--- a/middleware/redirects/redirects_test.go
+++ b/middleware/redirects/redirects_test.go
@@ -60,13 +60,22 @@ func TestDynamicRedirect(t *testing.T) {
 	router.HandleFunc("/redirected{uri:.*}", func(w http.ResponseWriter, req *http.Request) {
 	})
 
-	Convey("Test that a redirect request reaches the handler", t, func() {
+	Convey("Test that a redirect request is redirected to the new url", t, func() {
 		req, _ := http.NewRequest("GET", "/original", nil)
 		w := httptest.NewRecorder()
 		testAlice.ServeHTTP(w, req)
 		So(w.Code, ShouldEqual, 301)
 		So(w.Header(), ShouldContainKey, "Location")
 		So(w.Header()["Location"], ShouldContain, "/redirected")
+	})
+
+	Convey("Test that a redirect request with a path extension is redirected to the new url with the same path extension", t, func() {
+		req, _ := http.NewRequest("GET", "/original/extension", nil)
+		w := httptest.NewRecorder()
+		testAlice.ServeHTTP(w, req)
+		So(w.Code, ShouldEqual, 301)
+		So(w.Header(), ShouldContainKey, "Location")
+		So(w.Header()["Location"], ShouldContain, "/redirected/extension")
 	})
 }
 

--- a/router/router.go
+++ b/router/router.go
@@ -20,6 +20,8 @@ type Handler http.Handler
 type Config struct {
 	HealthCheckHandler     func(w http.ResponseWriter, req *http.Request)
 	AnalyticsHandler       http.Handler
+	AreaProfileEnabled     bool
+	AreaProfileHandler     http.Handler
 	DownloadHandler        http.Handler
 	DatasetHandler         http.Handler
 	CookieHandler          http.Handler

--- a/router/router.go
+++ b/router/router.go
@@ -65,7 +65,10 @@ func New(cfg Config) http.Handler {
 	router.Handle("/filter-outputs/{uri:.*}", cfg.FilterHandler)
 	router.Handle("/feedback{uri:.*}", cfg.FeedbackHandler)
 
-	if cfg.GeographyEnabled {
+	if cfg.AreaProfileEnabled {
+		router.Handle("/areas{uri:.*}", cfg.AreaProfileHandler)
+		router.Handle("/geography{uri:.*}", cfg.GeographyHandler)
+	} else if cfg.GeographyEnabled {
 		router.Handle("/geography{uri:.*}", cfg.GeographyHandler)
 	}
 


### PR DESCRIPTION
### What

Added routes handler for the area profiles controller ('/areas')
Added a redirect handler for the '/geography' routes to go to '/areas'
Added feature flag for enabling area profile routes.

### How to review

Set the AreaProfilesRoutesEnabled config variable to true.

_The areas routes have not been added to the dp-frontend-area-profile, in order to test they will be._
The easiest way to do this is add the following lines to the Setup function in routes/routes.go
```
r.StrictSlash(true).Path("/areas").Methods("GET").HandlerFunc(handlers.HelloWorld(*cfg))
r.StrictSlash(true).Path("/areas/{id}").Methods("GET").HandlerFunc(handlers.HelloWorld(*cfg))
```
With dp-frontend-router and dp-frontend-area-profiles running

In your browser go to localhost:20000/areas
You should receive a HelloWorld json message

In your browser go to localhost:20000/areas/{id}
You should receive a HelloWorld json message

In your browser go to localhost:20000/geography
You should be redirected to localhost:20000/areas and receive a HelloWorld json message

In your browser go to localhost:20000/geography/{id}
You should be redirected to localhost:20000/areas/{id} (where the id matches the one from the original url)
and receive a HelloWorld json message

### Who can review

Anyone but me
