### PR TITLE
Make proxy timeout configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	EnableSearchABTest                  bool          `envconfig:"ENABLE_SEARCH_AB_TEST"`
 	SearchABTestPercentage              int           `envconfig:"SEARCH_AB_TEST_PERCENTAGE"`
 	CensusHubRoutesEnabled              bool          `envconfig:"CENSUS_HUB_ROUTES_ENABLED"`
+	ProxyTimeout                        time.Duration `envconfig:"PROXY_TIMEOUT"`
 }
 
 var cfg *Config
@@ -84,6 +85,7 @@ func Get() (*Config, error) {
 		ZebedeeRequestMaximumRetries:        0,
 		EnableSearchABTest:                  false,
 		SearchABTestPercentage:              10,
+		ProxyTimeout:                        5 * time.Second,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,6 +48,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.ZebedeeRequestMaximumTimeoutSeconds, ShouldEqual, 5*time.Second)
 				So(cfg.ZebedeeRequestMaximumRetries, ShouldEqual, 0)
 				So(cfg.CensusHubRoutesEnabled, ShouldBeFalse)
+				So(cfg.ProxyTimeout, ShouldEqual, 5*time.Second)
 			})
 		})
 	})

--- a/main.go
+++ b/main.go
@@ -153,22 +153,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	downloadHandler := createReverseProxy("download", downloaderURL)
-	cookieHandler := createReverseProxy("cookies", cookiesControllerURL)
-	datasetHandler := createReverseProxy("datasets", datasetControllerURL)
-	filterHandler := createReverseProxy("filters", filterDatasetControllerURL)
-	feedbackHandler := createReverseProxy("feedback", feedbackControllerURL)
-	searchHandler := createReverseProxy("search", searchControllerURL)
-	homepageHandler := createReverseProxy("homepage", homepageControllerURL)
-	babbageHandler := createReverseProxy("babbage", babbageURL)
-	areaProfileHandler := createReverseProxy("areas", areaProfileControllerURL)
-	filterFlexHandler := createReverseProxy("flex", filterFlexDatasetServiceURL)
-	interactivesHandler := createReverseProxy("interactives", interactivesControllerURL)
+	downloadHandler := createReverseProxy("download", downloaderURL, cfg.ProxyTimeout)
+	cookieHandler := createReverseProxy("cookies", cookiesControllerURL, cfg.ProxyTimeout)
+	datasetHandler := createReverseProxy("datasets", datasetControllerURL, cfg.ProxyTimeout)
+	filterHandler := createReverseProxy("filters", filterDatasetControllerURL, cfg.ProxyTimeout)
+	feedbackHandler := createReverseProxy("feedback", feedbackControllerURL, cfg.ProxyTimeout)
+	searchHandler := createReverseProxy("search", searchControllerURL, cfg.ProxyTimeout)
+	homepageHandler := createReverseProxy("homepage", homepageControllerURL, cfg.ProxyTimeout)
+	babbageHandler := createReverseProxy("babbage", babbageURL, cfg.ProxyTimeout)
+	areaProfileHandler := createReverseProxy("areas", areaProfileControllerURL, cfg.ProxyTimeout)
+	filterFlexHandler := createReverseProxy("flex", filterFlexDatasetServiceURL, cfg.ProxyTimeout)
+	interactivesHandler := createReverseProxy("interactives", interactivesControllerURL, cfg.ProxyTimeout)
 	var geographyHandler http.Handler
 	if cfg.AreaProfilesRoutesEnabled {
 		geographyHandler = redirects.DynamicRedirectHandler("/geography", "/areas")
 	} else {
-		geographyHandler = createReverseProxy("geography", geographyControllerURL)
+		geographyHandler = createReverseProxy("geography", geographyControllerURL, cfg.ProxyTimeout)
 	}
 
 	routerConfig := router.Config{
@@ -278,13 +278,13 @@ func abHandler(a, b http.Handler, percentA int) http.Handler {
 	})
 }
 
-func createReverseProxy(proxyName string, proxyURL *url.URL) http.Handler {
+func createReverseProxy(proxyName string, proxyURL *url.URL, timeout time.Duration) http.Handler {
 	proxy := httputil.NewSingleHostReverseProxy(proxyURL)
 	director := proxy.Director
 	proxy.Transport = &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   5 * time.Second,
+			Timeout:   timeout,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
 		MaxIdleConns:          100,


### PR DESCRIPTION
### What

Make the proxy timeout configurable so that we can increase the value if needed in production if we are experiences performance issues. When the requests timeout the user is returned a 502, so having the option of increasing the timeout as a support option is a useful tool.

### How to review

Ensure that the changes make sense.

### Who can review

!me
