### PR TITLE
Fix bug in a/b testing of new search

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 | ZEBEDEE_REQUEST_MAXIMUM_RETRIES | 0                                         | The number of retry attempts to make to Zebedee                                    |
 | ENABLE_SEARCH_AB_TEST           | false                                     | Enable AB search                                                                   |
 | SEARCH_AB_TEST_PERCENTAGE       | 10                                        | AB search percentage                                                               |
-| PROXY_TIMEOUT                   | 5s                                        | The timeout for proxied requests                                                   |
+| PROXY_TIMEOUT                   | 5s                                        | The write timeout for proxied requests                                             |
 
 ### Licence
 

--- a/main.go
+++ b/main.go
@@ -153,22 +153,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	downloadHandler := createReverseProxy("download", downloaderURL, cfg.ProxyTimeout)
-	cookieHandler := createReverseProxy("cookies", cookiesControllerURL, cfg.ProxyTimeout)
-	datasetHandler := createReverseProxy("datasets", datasetControllerURL, cfg.ProxyTimeout)
-	filterHandler := createReverseProxy("filters", filterDatasetControllerURL, cfg.ProxyTimeout)
-	feedbackHandler := createReverseProxy("feedback", feedbackControllerURL, cfg.ProxyTimeout)
-	searchHandler := createReverseProxy("search", searchControllerURL, cfg.ProxyTimeout)
-	homepageHandler := createReverseProxy("homepage", homepageControllerURL, cfg.ProxyTimeout)
-	babbageHandler := createReverseProxy("babbage", babbageURL, cfg.ProxyTimeout)
-	areaProfileHandler := createReverseProxy("areas", areaProfileControllerURL, cfg.ProxyTimeout)
-	filterFlexHandler := createReverseProxy("flex", filterFlexDatasetServiceURL, cfg.ProxyTimeout)
-	interactivesHandler := createReverseProxy("interactives", interactivesControllerURL, cfg.ProxyTimeout)
+	downloadHandler := createReverseProxy("download", downloaderURL)
+	cookieHandler := createReverseProxy("cookies", cookiesControllerURL)
+	datasetHandler := createReverseProxy("datasets", datasetControllerURL)
+	filterHandler := createReverseProxy("filters", filterDatasetControllerURL)
+	feedbackHandler := createReverseProxy("feedback", feedbackControllerURL)
+	searchHandler := createReverseProxy("search", searchControllerURL)
+	homepageHandler := createReverseProxy("homepage", homepageControllerURL)
+	babbageHandler := createReverseProxy("babbage", babbageURL)
+	areaProfileHandler := createReverseProxy("areas", areaProfileControllerURL)
+	filterFlexHandler := createReverseProxy("flex", filterFlexDatasetServiceURL)
+	interactivesHandler := createReverseProxy("interactives", interactivesControllerURL)
 	var geographyHandler http.Handler
 	if cfg.AreaProfilesRoutesEnabled {
 		geographyHandler = redirects.DynamicRedirectHandler("/geography", "/areas")
 	} else {
-		geographyHandler = createReverseProxy("geography", geographyControllerURL, cfg.ProxyTimeout)
+		geographyHandler = createReverseProxy("geography", geographyControllerURL)
 	}
 
 	routerConfig := router.Config{
@@ -209,7 +209,7 @@ func main() {
 		Addr:         cfg.BindAddr,
 		Handler:      httpHandler,
 		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		WriteTimeout: cfg.ProxyTimeout,
 		IdleTimeout:  120 * time.Second,
 	}
 
@@ -278,13 +278,13 @@ func abHandler(a, b http.Handler, percentA int) http.Handler {
 	})
 }
 
-func createReverseProxy(proxyName string, proxyURL *url.URL, timeout time.Duration) http.Handler {
+func createReverseProxy(proxyName string, proxyURL *url.URL) http.Handler {
 	proxy := httputil.NewSingleHostReverseProxy(proxyURL)
 	director := proxy.Director
 	proxy.Transport = &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   timeout,
+			Timeout:   5 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
 		MaxIdleConns:          100,


### PR DESCRIPTION
### What

Fix a bug with the a/b testing of search; manipulating the dates for both old and new search may allow both to be rendered to the user.

### How to review

- Manipulate the cookie by changing the expiry date for both old and new search to a time in the future and you should get new search results rendered only

### Who can review

Anyone
