### PR TITLE
remove trailing slash from dp-census-atlas routes

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -103,7 +103,7 @@ func New(cfg Config) http.Handler {
 	}
 
 	if cfg.CensusAtlasEnabled {
-		router.Handle("/census-atlas/{uri:.*}", cfg.CensusAtlasHandler)
+		router.Handle("/census-atlas{uri:.*}", cfg.CensusAtlasHandler)
 	}
 
 	// if the request is for a file go directly to babbage instead of using the allRoutesMiddleware

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -595,7 +595,7 @@ func TestRouter(t *testing.T) {
 
 		Convey("When a census atlas request is made, but the census atlas handler is not enabled", func() {
 
-			url := "/census-atlas/"
+			url := "/census-atlas"
 			req := httptest.NewRequest("GET", url, nil)
 			res := httptest.NewRecorder()
 
@@ -610,7 +610,7 @@ func TestRouter(t *testing.T) {
 
 		Convey("When a census atlas request is made, and the census atlas handler is enabled", func() {
 
-			url := "/census-atlas/"
+			url := "/census-atlas"
 			req := httptest.NewRequest("GET", url, nil)
 			res := httptest.NewRecorder()
 


### PR DESCRIPTION
### What

Remove  trailing slash from dp-census-atlas as it seems to be breaking proxying

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
