### PR TITLE
add search redirects

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	HomepageControllerURL               string        `envconfig:"HOMEPAGE_CONTROLLER_URL"`
 	InteractivesControllerURL           string        `envconfig:"INTERACTIVES_CONTROLLER_URL"`
 	InteractivesRoutesEnabled           bool          `envconfig:"INTERACTIVES_ROUTES_ENABLED"`
+	LegacySearchRedirectsEnabled        bool          `envconfig:"LEGACY_SEARCH_REDIRECTS_ENABLED"`
 	NewDatasetRoutingEnabled            bool          `envconfig:"NEW_DATASET_ROUTING_ENABLED"`
 	PatternLibraryAssetsPath            string        `envconfig:"PATTERN_LIBRARY_ASSETS_PATH"`
 	ProxyTimeout                        time.Duration `envconfig:"PROXY_TIMEOUT"`
@@ -90,6 +91,7 @@ func Get() (*Config, error) {
 		HomepageControllerURL:               "http://localhost:24400",
 		InteractivesControllerURL:           "http://localhost:27300",
 		InteractivesRoutesEnabled:           false,
+		LegacySearchRedirectsEnabled:        false,
 		NewDatasetRoutingEnabled:            false,
 		PatternLibraryAssetsPath:            "https://cdn.ons.gov.uk/sixteens/f816ac8",
 		ProxyTimeout:                        5 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,6 +35,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.ReleaseCalendarRoutePrefix, ShouldEqual, "")
 				So(cfg.InteractivesControllerURL, ShouldEqual, "http://localhost:27300")
 				So(cfg.InteractivesRoutesEnabled, ShouldBeFalse)
+				So(cfg.LegacySearchRedirectsEnabled, ShouldBeFalse)
 				So(cfg.APIRouterURL, ShouldEqual, "http://localhost:23200/v1")
 				So(cfg.DownloaderURL, ShouldEqual, "http://localhost:23400")
 				So(cfg.AreaProfilesControllerURL, ShouldEqual, "http://localhost:26600")

--- a/main.go
+++ b/main.go
@@ -175,6 +175,10 @@ func main() {
 	filterHandler := createReverseProxy("filters", filterDatasetControllerURL)
 	feedbackHandler := createReverseProxy("feedback", feedbackControllerURL)
 	searchHandler := createReverseProxy("search", searchControllerURL)
+	if cfg.LegacySearchRedirectsEnabled {
+		searchHandler = redirects.DynamicRedirectHandler("/searchdata", "/search")
+		searchHandler = redirects.DynamicRedirectHandler("/searchpublication", "/search")
+	}
 	relcalHandler := createReverseProxy("relcal", relcalControllerURL)
 	homepageHandler := createReverseProxy("homepage", homepageControllerURL)
 	babbageHandler := createReverseProxy("babbage", babbageURL)

--- a/middleware/redirects/redirects.go
+++ b/middleware/redirects/redirects.go
@@ -84,12 +84,15 @@ func Handler(h http.Handler) http.Handler {
 	})
 }
 
-// DynamicRedirectHandler redirects requests to the provide 'to' base path
+// DynamicRedirectHandler redirects requests to the provide 'to' base path whilst keeping all the other information of the request url
 func DynamicRedirectHandler(redirectFrom, redirectTo string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		redirect := strings.Replace(req.URL.Path, redirectFrom, redirectTo, 1)
-		log.Info(req.Context(), "redirect found", log.Data{"location": redirect}, log.HTTP(req, 0, 0, nil, nil))
-		http.Redirect(w, req, redirect, http.StatusMovedPermanently)
+		redirect := *req.URL
+		redirect.Path = strings.Replace(req.URL.Path, redirectFrom, redirectTo, 1)
+		redirectURL := redirect.String()
+
+		log.Info(req.Context(), "redirect found", log.Data{"location": redirectURL}, log.HTTP(req, 0, 0, nil, nil))
+		http.Redirect(w, req, redirectURL, http.StatusMovedPermanently)
 		return
 	})
 }

--- a/middleware/redirects/redirects_test.go
+++ b/middleware/redirects/redirects_test.go
@@ -77,6 +77,15 @@ func TestDynamicRedirect(t *testing.T) {
 		So(w.Header(), ShouldContainKey, "Location")
 		So(w.Header()["Location"], ShouldContain, "/redirected/extension")
 	})
+
+	Convey("Test that a redirect request with parameters is redirected to the new url with the same parameters", t, func() {
+		req, _ := http.NewRequest("GET", "/original?q=test&page=2", nil)
+		w := httptest.NewRecorder()
+		testAlice.ServeHTTP(w, req)
+		So(w.Code, ShouldEqual, 301)
+		So(w.Header(), ShouldContainKey, "Location")
+		So(w.Header()["Location"], ShouldContain, "/redirected?q=test&page=2")
+	})
 }
 
 func TestInit(t *testing.T) {


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Redirect requests to `/searchdata` and `/searchpublication` to `/search`. 
- This should handle any query parameters on the end of uri and append this to `/search`
- The status code should return a `301`

### How to review
**Describe the steps required to test the changes.**
- Check if the test passes
- Check if the code changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone