### PR TITLE
Redirect to new location of measuring progress gdp and beyond page

### DIFF
--- a/assets/redirects/redirects.csv
+++ b/assets/redirects/redirects.csv
@@ -265,3 +265,4 @@
 /census/censustransformationprogramme/census2021outputs/releaseplans,/census/aboutcensus/releaseplans
 /census/censuscustomerservices,/census/aboutcensus/contactcensuscustomerservices
 /census/,/census
+/news/statementsandletters/measuringprogressgdpandbeyond,/news/news/measuringprogressgdpandbeyond


### PR DESCRIPTION
### What

Another redirect added, incorrect location of page on website moved to new location

### How to review

Redirect from:
`<domain>/news/statementsandletters/measuringprogressgdpandbeyond`
to:
`<domain>/news/news/measuringprogressgdpandbeyond`

### Who can review

Anyone
