### PR TITLE
census-atlas path /census-atlas -> /census/maps in router.go

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -75,6 +75,11 @@ func New(cfg Config) http.Handler {
 	alice := alice.New(middleware...).Then(router)
 
 	router.Handle("/", cfg.HomepageHandler)
+
+	if cfg.CensusAtlasEnabled {
+		router.Handle("/census/maps{uri:.*}", cfg.CensusAtlasHandler)
+	}
+
 	router.Handle("/census", cfg.HomepageHandler)
 
 	router.Handle("/redir/{data:.*}", cfg.AnalyticsHandler)
@@ -120,10 +125,6 @@ func New(cfg Config) http.Handler {
 
 	if cfg.InteractivesEnabled {
 		router.Handle("/interactives/{uri:.*}", cfg.InteractivesHandler)
-	}
-
-	if cfg.CensusAtlasEnabled {
-		router.Handle("/census-atlas{uri:.*}", cfg.CensusAtlasHandler)
 	}
 
 	// if the request is for a file go directly to babbage instead of using the allRoutesMiddleware

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -661,7 +661,7 @@ func TestRouter(t *testing.T) {
 
 		Convey("When a census atlas request is made, and the census atlas handler is enabled", func() {
 
-			url := "/census-atlas"
+			url := "/census/maps"
 			req := httptest.NewRequest("GET", url, nil)
 			res := httptest.NewRecorder()
 


### PR DESCRIPTION
### What

commit 76149aa0130ee619b546e6cf34456c69b133b1f9 (HEAD -> feat/new-url-for-census-atlas, origin/feat/new-url-for-census-atlas)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Fri Sep 16 10:28:43 2022 +0100

    census-atlas path /census-atlas -> /census/maps in router.go

    - Move census-atlas (or census-maps as its now known) from its
    old path at /census-atlas to its new one at /census/maps. This
    is placed above the more general /census path in router.go to
    avoid clashes.

    These changes needed to better associate census-maps with census
    content.

### How to review

Read the code, check the tests pass

To test locally:
- run the front-end router locally with the census atlas routes enable with `CENSUS_ATLAS_ROUTES_ENABLED=true make debug`
- pull the census-atlas (https://github.com/ONSdigital/dp-census-atlas) and checkout the `feat/new-basepath-maps/census` branch
- install dependencies with `npm install`
- build for ONS infrastructure with `npm run build:ons`
- run the atlas locally with `PORT=28100 ENV_NAME=sandbox node build/index.js`
- in a browser, go to `localhost:20000/census/maps` - you should see the atlas.
 

### Who can review

Anyone