### PR TITLE
Release/1.50.0

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -75,6 +75,11 @@ func New(cfg Config) http.Handler {
 	alice := alice.New(middleware...).Then(router)
 
 	router.Handle("/", cfg.HomepageHandler)
+
+	if cfg.CensusAtlasEnabled {
+		router.Handle("/census/maps{uri:.*}", cfg.CensusAtlasHandler)
+	}
+
 	router.Handle("/census", cfg.HomepageHandler)
 
 	router.Handle("/redir/{data:.*}", cfg.AnalyticsHandler)
@@ -120,10 +125,6 @@ func New(cfg Config) http.Handler {
 
 	if cfg.InteractivesEnabled {
 		router.Handle("/interactives/{uri:.*}", cfg.InteractivesHandler)
-	}
-
-	if cfg.CensusAtlasEnabled {
-		router.Handle("/census-atlas{uri:.*}", cfg.CensusAtlasHandler)
 	}
 
 	// if the request is for a file go directly to babbage instead of using the allRoutesMiddleware

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -661,7 +661,7 @@ func TestRouter(t *testing.T) {
 
 		Convey("When a census atlas request is made, and the census atlas handler is enabled", func() {
 
-			url := "/census-atlas"
+			url := "/census/maps"
 			req := httptest.NewRequest("GET", url, nil)
 			res := httptest.NewRecorder()
 


### PR DESCRIPTION
Release 1.50.0

- change path for census-atlas from /census-atlas to /census/maps to better associate it with other census content.