### PR TITLE
add X-Frame-Options header exception for /census/maps

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -152,7 +152,8 @@ func SecurityHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.URL.Path != "/embed" &&
 			!strings.HasPrefix(req.URL.Path, "/visualisations/") &&
-			!strings.HasPrefix(req.URL.Path, "/interactives/") {
+			!strings.HasPrefix(req.URL.Path, "/interactives/") &&
+			!strings.HasPrefix(req.URL.Path, "/census/maps/") {
 			w.Header().Set(HttpHeaderKeyXFrameOptions, "SAMEORIGIN")
 		}
 		h.ServeHTTP(w, req)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -50,6 +50,7 @@ func TestSecurityHandler(t *testing.T) {
 				"/embed",
 				"/visualisations/path",
 				"/interactives/path",
+				"/census/maps/path",
 			}
 			for i, url := range urls {
 				req := httptest.NewRequest(http.MethodGet, url, nil)


### PR DESCRIPTION
### What

commit 3e64982ffebd39df6b8080d67ec0d813b87e3c57 (HEAD -> feature/add-x-frame-block-exception-for-census-maps, origin/feature/add-x-frame-block-exception-for-census-maps)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue Oct 11 13:22:46 2022 +0100

    add X-Frame-Options header exception for /census/maps

    - Add /census/maps path to list of those excluded from having
    X-Frame-Options: SAMEORIGIN header set in router.SecurityHandler
    - Add /census/maps to list of tested paths in router_test.TestSecurityHandler

    These changes needed to allow embedded of census-maps (aka dp-census-atlas)
    in iFrames.

### How to review

- Read the code
- Run the tests
- Try it locally:
  * run this branch of dp-frontend-router locally with census atlas routes enabled: `CENSUS_ATLAS_ROUTES_ENABLED=True make debug`
  * run [dp-census-atlas](https://github.com/ONSdigital/dp-census-atlas) locally in production-like config with:
     * `npm run build:ons`
     * `PORT=28100 ENV_NAME=dev node build/index.js`
  * make a html file with the following content: 
  ```
  Census Maps embed test:
  <iframe height="100%" width="100%" title="ONS Census Maps" frameborder="0" src="http://localhost:20000/census/maps/choropleth/population/household-deprivation/default/household-is-not-deprived-in-any-dimension?embed=true" />
  ```
  * run the html file in your browser. You should see the census-maps UI successfully embedded, having been proxied by the local front-end router.
    

### Who can review

Anyone