### PR TITLE
Modified reflex to run debug-run instead of debug

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,8 +1,13 @@
-FROM golang:1.17-stretch AS base
+FROM golang:1.19-bullseye AS base
 
 ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London
 
-RUN GOBIN=/bin go get github.com/cespare/reflex
+RUN GOBIN=/bin go install github.com/cespare/reflex@v0.3.1
+RUN PATH=$PATH:/bin
 
+# Clean cache, as we want all modules in the container to be under /go/.go/path
+RUN go clean -modcache
+
+# Map between the working directories of dev and live
+RUN ln -s /go /dp-frontend-router
 WORKDIR /dp-frontend-router
-

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ debug: assets-debug
 	HUMAN_LOG=1 DEBUG=1 $(BINPATH)/dp-frontend-router
 
 .PHONY: debug-run
-debug-run:
+debug-run: assets-debug
 	HUMAN_LOG=1 go run -ldflags "-X main.BuildTime=$(BUILD_TIME) -X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -race $(LDFLAGS) main.go
 	clean-assets
 

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.17.3
+    tag: 1.19.3
 
 inputs:
   - name: dp-frontend-router

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.17.3
+    tag: 1.19.3
 
 inputs:
   - name: dp-frontend-router

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-frontend-router
 
-go 1.17
+go 1.19
 
 replace golang.org/x/text v0.3.7 => golang.org/x/text v0.3.8
 

--- a/reflex
+++ b/reflex
@@ -1,3 +1,3 @@
-# Watch all files ending in .go, excluding files in `.go` directory or files
+# Watch all files ending in .go, excluding files in `.go` or `assets` directory or files
 # ending in `_test.go` & run `make debug-run` when any matching file is changed
--s -r \.go$ -R ^\.go/ -R _test\.go$ make debug-run
+-s -r \.go$ -R ^\.go/ -R ^assets/ -R _test\.go$ make debug-run

--- a/reflex
+++ b/reflex
@@ -1,3 +1,3 @@
 # Watch all files ending in .go, excluding files in `.go` directory or files
-# ending in `_test.go` & run `make debug` when any matching file is changed
+# ending in `_test.go` & run `make debug-run` when any matching file is changed
 -s -r \.go$ -R ^\.go/ -R _test\.go$ make debug-run


### PR DESCRIPTION
### What

- [Trello card](https://trello.com/c/S2KyzIGX/1024-create-census-hub-stack-using-docker)
- Modify `reflex` file to run `debug-run` instead of `debug`

### How to review

- You may run the dp-compose stack using [the branch for this PR](https://github.com/ONSdigital/dp-compose/pull/123)

### Who can review

Anyone