### PR TITLE
add routing for dataset finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 | SEARCH_AB_TEST_PERCENTAGE        | 10                                        | AB search percentage                                                                     |
 | PROXY_TIMEOUT                    | 5s                                        | The write timeout for proxied requests                                                   |
 | NEW_DATASET_ROUTING_ENABLED      | false                                     | Flag to enable dataset page routing to dp-frontend-dataset-controller instead of babbage |
+| DATASET_FINDER_ENABLED           | false                                     | Flag to enabled routing to dataset finder page in search                                 |
 
 ### Licence
 

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	ContentTypeByteLimit                int           `envconfig:"CONTENT_TYPE_BYTE_LIMIT"`
 	CookiesControllerURL                string        `envconfig:"COOKIES_CONTROLLER_URL"`
 	DatasetControllerURL                string        `envconfig:"DATASET_CONTROLLER_URL"`
+	DatasetFinderEnabled                bool          `envconfig:"DATASET_FINDER_ENABLED"`
 	DownloaderURL                       string        `envconfig:"DOWNLOADER_URL"`
 	EnableReleaseCalendarABTest         bool          `envconfig:"ENABLE_RELEASE_CALENDAR_AB_TEST"`
 	EnableSearchABTest                  bool          `envconfig:"ENABLE_SEARCH_AB_TEST"`
@@ -79,6 +80,7 @@ func Get() (*Config, error) {
 		ContentTypeByteLimit:                5000000,
 		CookiesControllerURL:                "http://localhost:24100",
 		DatasetControllerURL:                "http://localhost:20200",
+		DatasetFinderEnabled:                false,
 		DownloaderURL:                       "http://localhost:23400",
 		EnableSearchABTest:                  false,
 		FeedbackControllerURL:               "http://localhost:25200",

--- a/main.go
+++ b/main.go
@@ -224,6 +224,7 @@ func main() {
 		ContentTypeByteLimit:         cfg.ContentTypeByteLimit,
 		CensusAtlasHandler:           censusAtlasHandler,
 		CensusAtlasEnabled:           cfg.CensusAtlasRoutesEnabled,
+		DatasetFinderEnabled:         cfg.DatasetFinderEnabled,
 	}
 
 	httpHandler := router.New(routerConfig)

--- a/router/router.go
+++ b/router/router.go
@@ -59,6 +59,7 @@ type Config struct {
 	BabbageHandler               http.Handler
 	CensusAtlasHandler           http.Handler
 	CensusAtlasEnabled           bool
+	DatasetFinderEnabled         bool
 }
 
 func New(cfg Config) http.Handler {
@@ -81,6 +82,10 @@ func New(cfg Config) http.Handler {
 	}
 
 	router.Handle("/census", cfg.HomepageHandler)
+
+	if cfg.DatasetFinderEnabled {
+		router.Handle("/census/find-a-dataset", cfg.SearchHandler)
+	}
 
 	router.Handle("/redir/{data:.*}", cfg.AnalyticsHandler)
 	router.Handle("/download/{uri:.*}", cfg.DownloadHandler)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -379,6 +379,41 @@ func TestRouter(t *testing.T) {
 				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 0)
 			})
 		})
+		Convey("When a dataset finder request is made, but the Dataset Finder is not enabled", func() {
+			url := "/census/find-a-dataset"
+			req := httptest.NewRequest("GET", url, nil)
+			res := httptest.NewRecorder()
+
+			config.DatasetFinderEnabled = false
+			r := router.New(config)
+			r.ServeHTTP(res, req)
+			Convey("Then no request is sent to the search handler", func() {
+				So(len(searchHandler.ServeHTTPCalls()), ShouldEqual, 0)
+			})
+			Convey("Then the request is sent to Babbage", func() {
+				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(babbageHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
+			})
+		})
+		Convey("When a dataset finder request is made, and the Dataset Finder is enabled", func() {
+			url := "/census/find-a-dataset"
+			req := httptest.NewRequest("GET", url, nil)
+			res := httptest.NewRecorder()
+
+			config.DatasetFinderEnabled = true
+			r := router.New(config)
+			r.ServeHTTP(res, req)
+			Convey("Then no requests are sent to Zebedee", func() {
+				So(len(zebedeeClient.GetWithHeadersCalls()), ShouldEqual, 0)
+			})
+			Convey("Then the request is sent to the search handler", func() {
+				So(len(searchHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(searchHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
+			})
+			Convey("Then no request is sent to Babbage", func() {
+				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 0)
+			})
+		})
 		Convey("When a homepage request is made", func() {
 			url := "/"
 			req := httptest.NewRequest("GET", url, nil)


### PR DESCRIPTION
### What

Added routing for new dataset finder page, hosted within frontend search controller

### How to review

With DATASET_FINDER_ENABLED off, router should fallback to babbage with /census/find-a-dataset. With it on, it should pass to dp-frontend-search-controller and 404 there instead. 

### Who can review

Developer.
