### PR TITLE
fix/remove 'enable_filter_flex_routes_enabled' feature toggle

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,6 @@ type Config struct {
 	FeedbackEnabled                     bool          `envconfig:"FEEDBACK_ENABLED"`
 	FilterDatasetControllerURL          string        `envconfig:"FILTER_DATASET_CONTROLLER_URL"`
 	FilterFlexDatasetServiceURL         string        `envconfig:"FILTER_FLEX_DATASET_SERVICE_URL"`
-	FilterFlexRoutesEnabled             bool          `envconfig:"FILTER_FLEX_ROUTES_ENABLED"`
 	GeographyControllerURL              string        `envconfig:"GEOGRAPHY_CONTROLLER_URL"`
 	GeographyEnabled                    bool          `envconfig:"GEOGRAPHY_ENABLED"`
 	HealthcheckCriticalTimeout          time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
@@ -87,7 +86,6 @@ func Get() (*Config, error) {
 		FeedbackEnabled:                     false,
 		FilterDatasetControllerURL:          "http://localhost:20001",
 		FilterFlexDatasetServiceURL:         "http://localhost:20100",
-		FilterFlexRoutesEnabled:             false,
 		GeographyControllerURL:              "http://localhost:23700",
 		GeographyEnabled:                    false,
 		HealthcheckCriticalTimeout:          90 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,7 +40,6 @@ func TestSpec(t *testing.T) {
 				So(cfg.AreaProfilesControllerURL, ShouldEqual, "http://localhost:26600")
 				So(cfg.AreaProfilesRoutesEnabled, ShouldBeFalse)
 				So(cfg.FilterFlexDatasetServiceURL, ShouldEqual, "http://localhost:20100")
-				So(cfg.FilterFlexRoutesEnabled, ShouldBeFalse)
 				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "https://cdn.ons.gov.uk/sixteens/f816ac8")
 				So(cfg.SiteDomain, ShouldEqual, "ons.gov.uk")
 				So(cfg.RedirectSecret, ShouldEqual, "secret")

--- a/main.go
+++ b/main.go
@@ -201,7 +201,6 @@ func main() {
 		FilterHandler:                filterHandler,
 		FilterClient:                 filterClient,
 		FeedbackHandler:              feedbackHandler,
-		FilterFlexEnabled:            cfg.FilterFlexRoutesEnabled,
 		FilterFlexHandler:            filterFlexHandler,
 		GeographyEnabled:             cfg.GeographyEnabled,
 		GeographyHandler:             geographyHandler,

--- a/router/router.go
+++ b/router/router.go
@@ -35,7 +35,6 @@ type Config struct {
 	CookieHandler                http.Handler
 	FilterHandler                http.Handler
 	FilterFlexHandler            http.Handler
-	FilterFlexEnabled            bool
 	FilterClient                 datasetType.FilterClient
 	FeedbackHandler              http.Handler
 	ContentTypeByteLimit         int
@@ -91,11 +90,7 @@ func New(cfg Config) http.Handler {
 	router.Handle("/download/{uri:.*}", cfg.DownloadHandler)
 	router.Handle("/cookies{uri:.*}", cfg.CookieHandler)
 	router.Handle("/datasets/{uri:.*}", cfg.DatasetHandler)
-	if cfg.FilterFlexEnabled {
-		router.Handle("/filters/{uri:.*}", datasetType.Handler(cfg.FilterClient, cfg.DatasetClient)(cfg.FilterHandler, cfg.FilterFlexHandler))
-	} else {
-		router.Handle("/filters/{uri:.*}", cfg.FilterHandler)
-	}
+	router.Handle("/filters/{uri:.*}", datasetType.Handler(cfg.FilterClient, cfg.DatasetClient)(cfg.FilterHandler, cfg.FilterFlexHandler))
 	router.Handle("/filter-outputs/{uri:.*}", cfg.FilterHandler)
 	router.Handle("/feedback{uri:.*}", cfg.FeedbackHandler)
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -193,7 +193,7 @@ func TestRouter(t *testing.T) {
 				So(datasetHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
 			})
 		})
-		Convey("When a filter request is made, but the filter/flex handler is not enabled", func() {
+		Convey("When a filter request is made for an invalid flexible dataset", func() {
 			url := "/filters/123"
 			req := httptest.NewRequest("GET", url, nil)
 			res := httptest.NewRecorder()
@@ -202,51 +202,22 @@ func TestRouter(t *testing.T) {
 			r.ServeHTTP(res, req)
 
 			Convey("Then no requests are sent to Zebedee", func() {
-				So(len(zebedeeClient.GetWithHeadersCalls()), ShouldEqual, 0)
+				So(zebedeeClient.GetWithHeadersCalls(), ShouldHaveLength, 0)
 			})
 
 			Convey("Then the request is sent to the filter handler", func() {
-				So(len(filterHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(filterHandler.ServeHTTPCalls(), ShouldHaveLength, 1)
 				So(filterHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
 			})
 
 			Convey("Then no requests are sent to the filter/flex handler", func() {
-				So(len(filterFlexHandler.ServeHTTPCalls()), ShouldEqual, 0)
-			})
-		})
-		Convey("When a filter request is made and the filter/flex route is enabled", func() {
-			url := "/filters/123"
-			req := httptest.NewRequest("GET", url, nil)
-			res := httptest.NewRecorder()
-			config.FilterFlexEnabled = true
-
-			filterableDataset := &mocks.DatasetClientMock{
-				GetFunc: func(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID string) (dataset.DatasetDetails, error) {
-					return dataset.DatasetDetails{
-						Type: "filterable",
-					}, nil
-				},
-			}
-			config.DatasetClient = filterableDataset
-
-			r := router.New(config)
-			r.ServeHTTP(res, req)
-			Convey("Then no requests are sent to Zebedee", func() {
-				So(len(zebedeeClient.GetWithHeadersCalls()), ShouldEqual, 0)
-			})
-			Convey("Then the request is sent to the filter handler", func() {
-				So(len(filterHandler.ServeHTTPCalls()), ShouldEqual, 1)
-				So(filterHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
-			})
-			Convey("Then no requests are sent to the filter/flex handler", func() {
-				So(len(filterFlexHandler.ServeHTTPCalls()), ShouldEqual, 0)
+				So(filterFlexHandler.ServeHTTPCalls(), ShouldHaveLength, 0)
 			})
 		})
 		Convey("When a filter request is made for a valid flexible dataset", func() {
 			url := "/filters/123"
 			req := httptest.NewRequest("GET", url, nil)
 			res := httptest.NewRecorder()
-			config.FilterFlexEnabled = true
 
 			flexDataset := &mocks.DatasetClientMock{
 				GetFunc: func(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID string) (dataset.DatasetDetails, error) {
@@ -273,7 +244,6 @@ func TestRouter(t *testing.T) {
 				So(filterHandler.ServeHTTPCalls(), ShouldHaveLength, 0)
 			})
 		})
-
 		Convey("When a filter-output request is made", func() {
 			url := "/filter-outputs/321"
 			req := httptest.NewRequest("GET", url, nil)


### PR DESCRIPTION
### What

Removed redundant feature toggle `FILTER_FLEX_ROUTES_ENABLED` as although the service is in `beta` it is unlikely to be decommissioned in the near future
✅ **Resolves** trello ticket [Remove FILTER_FLEX_ROUTES_ENABLED from frontend router](https://trello.com/c/DUOstDy2/6040-remove-filterflexroutesenabled-from-frontend-router)

### How to review

Sense check

### Who can review

!me
