### PR TITLE
Remove old search routing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,6 @@ type Config struct {
 	DatasetFinderEnabled                bool          `envconfig:"DATASET_FINDER_ENABLED"`
 	DownloaderURL                       string        `envconfig:"DOWNLOADER_URL"`
 	EnableReleaseCalendarABTest         bool          `envconfig:"ENABLE_RELEASE_CALENDAR_AB_TEST"`
-	EnableSearchABTest                  bool          `envconfig:"ENABLE_SEARCH_AB_TEST"`
 	FeedbackControllerURL               string        `envconfig:"FEEDBACK_CONTROLLER_URL"`
 	FeedbackEnabled                     bool          `envconfig:"FEEDBACK_ENABLED"`
 	FilterDatasetControllerURL          string        `envconfig:"FILTER_DATASET_CONTROLLER_URL"`
@@ -45,7 +44,6 @@ type Config struct {
 	ReleaseCalendarRoutePrefix          string        `envconfig:"RELEASE_CALENDAR_ROUTE_PREFIX"`
 	ReleaseCalendarABTestPercentage     int           `envconfig:"RELEASE_CALENDAR_AB_TEST_PERCENTAGE"`
 	RendererURL                         string        `envconfig:"RENDERER_URL"`
-	SearchABTestPercentage              int           `envconfig:"SEARCH_AB_TEST_PERCENTAGE"`
 	SearchControllerURL                 string        `envconfig:"SEARCH_CONTROLLER_URL"`
 	SearchRoutesEnabled                 bool          `envconfig:"SEARCH_ROUTES_ENABLED"`
 	SiteDomain                          string        `envconfig:"SITE_DOMAIN"`
@@ -81,7 +79,6 @@ func Get() (*Config, error) {
 		DatasetControllerURL:                "http://localhost:20200",
 		DatasetFinderEnabled:                false,
 		DownloaderURL:                       "http://localhost:23400",
-		EnableSearchABTest:                  false,
 		FeedbackControllerURL:               "http://localhost:25200",
 		FeedbackEnabled:                     false,
 		FilterDatasetControllerURL:          "http://localhost:20001",
@@ -101,9 +98,8 @@ func Get() (*Config, error) {
 		ReleaseCalendarControllerURL:        "http://localhost:27700",
 		ReleaseCalendarEnabled:              false,
 		RendererURL:                         "http://localhost:20010",
-		SearchABTestPercentage:              10,
 		SearchControllerURL:                 "http://localhost:25000",
-		SearchRoutesEnabled:                 false,
+		SearchRoutesEnabled:                 true,
 		SiteDomain:                          "ons.gov.uk",
 		SQSAnalyticsURL:                     "",
 		ZebedeeRequestMaximumRetries:        0,
@@ -123,15 +119,6 @@ func Get() (*Config, error) {
 	cfg.ReleaseCalendarRoutePrefix = validatePrivatePrefix(cfg.ReleaseCalendarRoutePrefix)
 
 	return cfg, nil
-}
-
-// IsEnableSearchABTest checks whether ab test is enabled and that percentage is a sensible int value
-func IsEnableSearchABTest(cfg Config) bool {
-	percentage := cfg.SearchABTestPercentage
-	if cfg.EnableSearchABTest && percentage > 0 && percentage < 100 {
-		return true
-	}
-	return false
 }
 
 // IsEnabledRelCalABTest checks whether ab test is enabled and that percentage is a sensible int value

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,7 +26,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.FeedbackEnabled, ShouldBeFalse)
 				So(cfg.GeographyEnabled, ShouldBeFalse)
 				So(cfg.SearchControllerURL, ShouldEqual, "http://localhost:25000")
-				So(cfg.SearchRoutesEnabled, ShouldBeFalse)
+				So(cfg.SearchRoutesEnabled, ShouldBeTrue)
 				So(cfg.ReleaseCalendarControllerURL, ShouldEqual, "http://localhost:27700")
 				So(cfg.ReleaseCalendarEnabled, ShouldBeFalse)
 				So(cfg.ReleaseCalendarRoutePrefix, ShouldEqual, "")
@@ -51,31 +51,6 @@ func TestSpec(t *testing.T) {
 				So(cfg.ZebedeeRequestMaximumRetries, ShouldEqual, 0)
 				So(cfg.ProxyTimeout, ShouldEqual, 5*time.Second)
 			})
-		})
-	})
-}
-
-func TestIsEnabledABSearch(t *testing.T) {
-	Convey("IsEnabledABSearch returns expected value", t, func() {
-		Convey("false when EnableSearchABTest is false", func() {
-			cfg := Config{EnableSearchABTest: false, SearchABTestPercentage: 10}
-			result := IsEnableSearchABTest(cfg)
-			So(result, ShouldBeFalse)
-		})
-		Convey("false when SearchABTestPercentage is below 0", func() {
-			cfg := Config{EnableSearchABTest: true, SearchABTestPercentage: -10}
-			result := IsEnableSearchABTest(cfg)
-			So(result, ShouldBeFalse)
-		})
-		Convey("false when SearchABTestPercentage is over 100", func() {
-			cfg := Config{EnableSearchABTest: true, SearchABTestPercentage: 110}
-			result := IsEnableSearchABTest(cfg)
-			So(result, ShouldBeFalse)
-		})
-		Convey("true when EnableSearchABTest is set and a sensible percentage int is used", func() {
-			cfg := Config{EnableSearchABTest: true, SearchABTestPercentage: 10}
-			result := IsEnableSearchABTest(cfg)
-			So(result, ShouldBeTrue)
 		})
 	})
 }

--- a/handlers/abtest/abtesthandler.go
+++ b/handlers/abtest/abtesthandler.go
@@ -8,9 +8,6 @@ import (
 )
 
 const (
-	SearchTestCookieAspect = "dsa-search"
-	SearchNewExit          = "exit-new-search"
-
 	RelcalTestCookieAspect = "dsa-release-calendar"
 	RelcalNewExit          = "exit-new-relcal"
 )

--- a/main.go
+++ b/main.go
@@ -132,7 +132,6 @@ func main() {
 
 	censusAtlasURL := urlFromConfig(ctx, "CensusAtlas", cfg.CensusAtlasURL)
 
-	enableSearchABTest := config.IsEnableSearchABTest(*cfg)
 	enableRelCalABTest := config.IsEnabledRelCalABTest(*cfg)
 
 	redirects.Init(assets.Asset)
@@ -214,8 +213,6 @@ func main() {
 		RelCalABTestPercentage:       cfg.ReleaseCalendarABTestPercentage,
 		InteractivesHandler:          interactivesHandler,
 		InteractivesEnabled:          cfg.InteractivesRoutesEnabled,
-		EnableSearchABTest:           enableSearchABTest,
-		SearchABTestPercentage:       cfg.SearchABTestPercentage,
 		SiteDomain:                   cfg.SiteDomain,
 		HomepageHandler:              homepageHandler,
 		BabbageHandler:               babbageHandler,

--- a/router/router.go
+++ b/router/router.go
@@ -45,8 +45,6 @@ type Config struct {
 	InteractivesHandler          http.Handler
 	LegacySearchRedirectsEnabled bool
 	SearchRoutesEnabled          bool
-	EnableSearchABTest           bool
-	SearchABTestPercentage       int
 	SiteDomain                   string
 	SearchHandler                http.Handler
 	RelCalHandler                http.Handler
@@ -110,7 +108,7 @@ func New(cfg Config) http.Handler {
 	}
 
 	if cfg.SearchRoutesEnabled {
-		router.Handle("/search", abtest.Handler(cfg.EnableSearchABTest, cfg.SearchHandler, cfg.BabbageHandler, cfg.SearchABTestPercentage, abtest.SearchTestCookieAspect, cfg.SiteDomain, abtest.SearchNewExit))
+		router.Handle("/search", cfg.SearchHandler)
 	}
 
 	if cfg.RelCalEnabled {


### PR DESCRIPTION
### What

Removed old search routing and corresponding AB testing. 

### How to review

Run locally and ensure that old search can't be found. 

### Who can review

Not me. 