### PR TITLE
fix shadow config var always reads config; other minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ audit:
 
 .PHONY: assets
 assets:
-	cd assets; go run github.com/jteeuwen/go-bindata/go-bindata -o redirects.go -pkg assets redirects/...
+	cd assets; go-bindata -o redirects.go -pkg assets redirects/...
 
 .PHONY: assets-debug
 assets-debug:
-	cd assets; go run github.com/jteeuwen/go-bindata/go-bindata -debug -o redirects.go -pkg assets redirects/...
+	cd assets; go-bindata -debug -o redirects.go -pkg assets redirects/...
 
 .PHONY: clean-assets
 clean-assets:

--- a/config/config.go
+++ b/config/config.go
@@ -67,7 +67,7 @@ func Get() (*Config, error) {
 		return cfg, nil
 	}
 
-	cfg := &Config{
+	cfg = &Config{
 		APIRouterURL:                 "http://localhost:23200/v1",
 		AreaProfilesControllerURL:    "http://localhost:26600",
 		AreaProfilesRoutesEnabled:    false,

--- a/handlers/abtest/abtesthandler.go
+++ b/handlers/abtest/abtesthandler.go
@@ -41,10 +41,12 @@ func abTestHandler(newHandler, old http.Handler, percentage int, aspectID, domai
 		aspect := cookies.GetABTestCookieAspect(req, aspectID)
 
 		if (aspect.New.IsZero() && aspect.Old.IsZero()) || (aspect.New.Before(now) && aspect.Old.Before(now)) {
+			// not used AB-test before OR (AB) cookie has expired
 			cookies.HandleCookieAndServ(w, req, newHandler, old, aspectID, domain, cookies.DefaultABTestRandomiser(percentage))
 			return
 		}
 
+		// cookie exists and is recent, so serve A or B
 		cookies.ServABTest(w, req, newHandler, old, aspect)
 	})
 }


### PR DESCRIPTION
### What

noticed that the `cfg` var was shadowed, forcing the config to be re-read each time `Get` was called

### How to review

no functional change, just tidier

### Who can review

!me
