### PR TITLE
Legacy cache Proxy Feature Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@
 | OTEL_EXPORTER_OTLP_ENDPOINT      | localhost:4317                            | Host and port for the OpenTelemetry endpoint                                             |
 | OTEL_SERVICE_NAME                | dp-frontend-router                        | Service name to report to telemetry tools                                                |
 | OTEL_BATCH_TIMEOUT               | 5s                                        | Interval between pushes to OT Collector                                                  |
-| OTEL_ENABLED                     | false                                     | Feature flag to enable OpenTelemetry
+| LEGACY_CACHE_PROXY_ENABLED       | false                                     | Flag to enable requests to Babbage to go through the dp-legacy-cache-proxy instead.      |
+| LEGACY_CACHE_PROXY_URL           | <http://localhost:29200>                  | The URL of dp-legacy-cache-proxy                                                         |
 
 ### Licence
 

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	HomepageControllerURL           string        `envconfig:"HOMEPAGE_CONTROLLER_URL"`
 	HTTPMaxConnections              int           `envconfig:"HTTP_MAX_CONNECTIONS"`
 	LegacySearchRedirectsEnabled    bool          `envconfig:"LEGACY_SEARCH_REDIRECTS_ENABLED"`
+	LegacyCacheProxyEnabled         bool          `envconfig:"LEGACY_CACHE_PROXY_ENABLED"`
+	LegacyCacheProxyURL             string        `envconfig:"LEGACY_CACHE_PROXY_URL"`
 	NewDatasetRoutingEnabled        bool          `envconfig:"NEW_DATASET_ROUTING_ENABLED"`
 	OTExporterOTLPEndpoint          string        `envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
 	OTServiceName                   string        `envconfig:"OTEL_SERVICE_NAME"`
@@ -89,6 +91,8 @@ func Get() (*Config, error) {
 		HomepageControllerURL:        "http://localhost:24400",
 		HTTPMaxConnections:           0,
 		LegacySearchRedirectsEnabled: false,
+		LegacyCacheProxyEnabled:      false,
+		LegacyCacheProxyURL:          "http://localhost:29200",
 		NewDatasetRoutingEnabled:     false,
 		OTExporterOTLPEndpoint:       "localhost:4317",
 		OTServiceName:                "dp-frontend-router",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -47,6 +47,8 @@ func TestSpec(t *testing.T) {
 				So(cfg.ZebedeeRequestMaximumTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.ZebedeeRequestMaximumRetries, ShouldEqual, 0)
 				So(cfg.ProxyTimeout, ShouldEqual, 5*time.Second)
+				So(cfg.LegacyCacheProxyEnabled, ShouldBeFalse)
+				So(cfg.LegacyCacheProxyURL, ShouldEqual, "http://localhost:29200")
 			})
 		})
 	})

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func main() {
 	homepageControllerURL, _ := parseURL(ctx, cfg.HomepageControllerURL, "HomepageControllerURL")
 	searchControllerURL, _ := parseURL(ctx, cfg.SearchControllerURL, "SearchControllerURL")
 	relcalControllerURL, _ := parseURL(ctx, cfg.ReleaseCalendarControllerURL, "ReleaseCalendarControllerURL")
+	legacyCacheProxyURL, _ := parseURL(ctx, cfg.LegacyCacheProxyURL, "LegacyCacheProxyURL")
 	babbageURL, _ := parseURL(ctx, cfg.BabbageURL, "BabbageURL")
 	downloaderURL, _ := parseURL(ctx, cfg.DownloaderURL, "DownloaderURL")
 	feedbackControllerURL, _ := parseURL(ctx, cfg.FeedbackControllerURL, "FeedbackControllerURL")
@@ -124,7 +125,12 @@ func main() {
 	searchHandler := createReverseProxy("search", searchControllerURL)
 	relcalHandler := createReverseProxy("relcal", relcalControllerURL)
 	homepageHandler := createReverseProxy("homepage", homepageControllerURL)
-	babbageHandler := createReverseProxy("babbage", babbageURL)
+	var babbageHandler http.Handler
+	if cfg.LegacyCacheProxyEnabled {
+		babbageHandler = createReverseProxy("legacyCacheProxy", legacyCacheProxyURL)
+	} else {
+		babbageHandler = createReverseProxy("babbage", babbageURL)
+	}
 	areaProfileHandler := createReverseProxy("areas", areaProfileControllerURL)
 	filterFlexHandler := createReverseProxy("flex", filterFlexDatasetServiceURL)
 	censusAtlasHandler := createReverseProxy("censusAtlas", censusAtlasURL)


### PR DESCRIPTION
### What

Added a new feature flag so that the requests to Babbage go to the proxy instead. 
Default value of _LEGACY_CACHE_PROXY_ENABLED_ is false

### How to review
1. Run babbage `./run.sh`
2. Run zebedee `./run-reader.sh` (requires content to have been generated as described in the zebedee README.md prior to this)
3. Set _LEGACY_CACHE_PROXY_ENABLED_ to true by running this on the terminal
`export LEGACY_CACHE_PROXY_ENABLED=true`
4. Run dp-frontend-router `make debug`
5. This requires changes that are part of [this Draft PR](https://github.com/ONSdigital/dp-legacy-cache-proxy/pull/4) in order to check that the call is made to the dp-legacy-cache-proxy. Checkout the [branch](https://github.com/ONSdigital/dp-legacy-cache-proxy/tree/feature/proxy-pass-through) on the above PR and run in dp-legacy-cache-proxy `make debug`
6. Make a request to a Babbage endpoint
e.g. http://localhost:20000/economy/environmentalaccounts/bulletins/ukenvironmentalaccounts/2013-06-26
7. HTML content should be returned 

### Who can review

Anyone from ONS