### PR TITLE
Redirect release calendar URLs to proxy

### DIFF
--- a/analytics/analyticstest/sqsclient.go
+++ b/analytics/analyticstest/sqsclient.go
@@ -11,19 +11,19 @@ import (
 
 // SQSClientMock is a mock implementation of analytics.SQSClient.
 //
-//     func TestSomethingThatUsesSQSClient(t *testing.T) {
+//	    func TestSomethingThatUsesSQSClient(t *testing.T) {
 //
-//         // make and configure a mocked analytics.SQSClient
-//         mockedSQSClient := &SQSClientMock{
-//             SendMessageFunc: func(ctx context.Context, params *sqs.SendMessageInput, optFns ...func(*sqs.Options)) (*sqs.SendMessageOutput, error) {
-// 	               panic("mock out the SendMessage method")
-//             },
-//         }
+//	        // make and configure a mocked analytics.SQSClient
+//	        mockedSQSClient := &SQSClientMock{
+//	            SendMessageFunc: func(ctx context.Context, params *sqs.SendMessageInput, optFns ...func(*sqs.Options)) (*sqs.SendMessageOutput, error) {
+//		               panic("mock out the SendMessage method")
+//	            },
+//	        }
 //
-//         // use mockedSQSClient in code that requires analytics.SQSClient
-//         // and then make assertions.
+//	        // use mockedSQSClient in code that requires analytics.SQSClient
+//	        // and then make assertions.
 //
-//     }
+//	    }
 type SQSClientMock struct {
 	// SendMessageFunc mocks the SendMessage method.
 	SendMessageFunc func(ctx context.Context, params *sqs.SendMessageInput, optFns ...func(*sqs.Options)) (*sqs.SendMessageOutput, error)
@@ -65,7 +65,8 @@ func (mock *SQSClientMock) SendMessage(ctx context.Context, params *sqs.SendMess
 
 // SendMessageCalls gets all the calls that were made to SendMessage.
 // Check the length with:
-//     len(mockedSQSClient.SendMessageCalls())
+//
+//	len(mockedSQSClient.SendMessageCalls())
 func (mock *SQSClientMock) SendMessageCalls() []struct {
 	Ctx    context.Context
 	Params *sqs.SendMessageInput

--- a/go.mod
+++ b/go.mod
@@ -65,5 +65,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240213162025-012b6fc9bca9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240213162025-012b6fc9bca9 // indirect
 	google.golang.org/grpc v1.61.1 // indirect
-	google.golang.org/protobuf v1.32.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -141,5 +141,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
 google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -123,12 +123,8 @@ func main() {
 	searchHandler := createReverseProxy("search", searchControllerURL)
 	relcalHandler := createReverseProxy("relcal", relcalControllerURL)
 	homepageHandler := createReverseProxy("homepage", homepageControllerURL)
-	var babbageHandler http.Handler
-	if cfg.LegacyCacheProxyEnabled {
-		babbageHandler = createReverseProxy("legacyCacheProxy", legacyCacheProxyURL)
-	} else {
-		babbageHandler = createReverseProxy("babbage", babbageURL)
-	}
+	babbageHandler := createReverseProxy("babbage", babbageURL)
+	proxyHandler := createReverseProxy("legacyCacheProxy", legacyCacheProxyURL)
 	areaProfileHandler := createReverseProxy("areas", areaProfileControllerURL)
 	filterFlexHandler := createReverseProxy("flex", filterFlexDatasetServiceURL)
 	censusAtlasHandler := createReverseProxy("censusAtlas", censusAtlasURL)
@@ -159,11 +155,13 @@ func main() {
 		SiteDomain:                   cfg.SiteDomain,
 		HomepageHandler:              homepageHandler,
 		BabbageHandler:               babbageHandler,
+		ProxyHandler:                 proxyHandler,
 		ZebedeeClient:                zebedeeClient,
 		ContentTypeByteLimit:         cfg.ContentTypeByteLimit,
 		CensusAtlasHandler:           censusAtlasHandler,
 		CensusAtlasEnabled:           cfg.CensusAtlasRoutesEnabled,
 		DatasetFinderEnabled:         cfg.DatasetFinderEnabled,
+		LegacyCacheProxyEnabled:      cfg.LegacyCacheProxyEnabled,
 	}
 
 	httpHandler := router.New(routerConfig)

--- a/middleware/allRoutes/allroutestest/zebedeeclient.go
+++ b/middleware/allRoutes/allroutestest/zebedeeclient.go
@@ -16,19 +16,19 @@ var _ allRoutes.ZebedeeClient = &ZebedeeClientMock{}
 
 // ZebedeeClientMock is a mock implementation of allRoutes.ZebedeeClient.
 //
-//     func TestSomethingThatUsesZebedeeClient(t *testing.T) {
+//	    func TestSomethingThatUsesZebedeeClient(t *testing.T) {
 //
-//         // make and configure a mocked allRoutes.ZebedeeClient
-//         mockedZebedeeClient := &ZebedeeClientMock{
-//             GetWithHeadersFunc: func(ctx context.Context, userAccessToken string, path string) ([]byte, http.Header, error) {
-// 	               panic("mock out the GetWithHeaders method")
-//             },
-//         }
+//	        // make and configure a mocked allRoutes.ZebedeeClient
+//	        mockedZebedeeClient := &ZebedeeClientMock{
+//	            GetWithHeadersFunc: func(ctx context.Context, userAccessToken string, path string) ([]byte, http.Header, error) {
+//		               panic("mock out the GetWithHeaders method")
+//	            },
+//	        }
 //
-//         // use mockedZebedeeClient in code that requires allRoutes.ZebedeeClient
-//         // and then make assertions.
+//	        // use mockedZebedeeClient in code that requires allRoutes.ZebedeeClient
+//	        // and then make assertions.
 //
-//     }
+//	    }
 type ZebedeeClientMock struct {
 	// GetWithHeadersFunc mocks the GetWithHeaders method.
 	GetWithHeadersFunc func(ctx context.Context, userAccessToken string, path string) ([]byte, http.Header, error)
@@ -70,7 +70,8 @@ func (mock *ZebedeeClientMock) GetWithHeaders(ctx context.Context, userAccessTok
 
 // GetWithHeadersCalls gets all the calls that were made to GetWithHeaders.
 // Check the length with:
-//     len(mockedZebedeeClient.GetWithHeadersCalls())
+//
+//	len(mockedZebedeeClient.GetWithHeadersCalls())
 func (mock *ZebedeeClientMock) GetWithHeadersCalls() []struct {
 	Ctx             context.Context
 	UserAccessToken string

--- a/middleware/datasetType/mocks/dataset.go
+++ b/middleware/datasetType/mocks/dataset.go
@@ -16,19 +16,19 @@ var _ datasetType.DatasetClient = &DatasetClientMock{}
 
 // DatasetClientMock is a mock implementation of datasetType.DatasetClient.
 //
-// 	func TestSomethingThatUsesDatasetClient(t *testing.T) {
+//	func TestSomethingThatUsesDatasetClient(t *testing.T) {
 //
-// 		// make and configure a mocked datasetType.DatasetClient
-// 		mockedDatasetClient := &DatasetClientMock{
-// 			GetFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, datasetID string) (dataset.DatasetDetails, error) {
-// 				panic("mock out the Get method")
-// 			},
-// 		}
+//		// make and configure a mocked datasetType.DatasetClient
+//		mockedDatasetClient := &DatasetClientMock{
+//			GetFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, datasetID string) (dataset.DatasetDetails, error) {
+//				panic("mock out the Get method")
+//			},
+//		}
 //
-// 		// use mockedDatasetClient in code that requires datasetType.DatasetClient
-// 		// and then make assertions.
+//		// use mockedDatasetClient in code that requires datasetType.DatasetClient
+//		// and then make assertions.
 //
-// 	}
+//	}
 type DatasetClientMock struct {
 	// GetFunc mocks the Get method.
 	GetFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, datasetID string) (dataset.DatasetDetails, error)
@@ -78,7 +78,8 @@ func (mock *DatasetClientMock) Get(ctx context.Context, userAuthToken string, se
 
 // GetCalls gets all the calls that were made to Get.
 // Check the length with:
-//     len(mockedDatasetClient.GetCalls())
+//
+//	len(mockedDatasetClient.GetCalls())
 func (mock *DatasetClientMock) GetCalls() []struct {
 	Ctx              context.Context
 	UserAuthToken    string

--- a/middleware/datasetType/mocks/filter.go
+++ b/middleware/datasetType/mocks/filter.go
@@ -16,19 +16,19 @@ var _ datasetType.FilterClient = &FilterClientMock{}
 
 // FilterClientMock is a mock implementation of datasetType.FilterClient.
 //
-// 	func TestSomethingThatUsesFilterClient(t *testing.T) {
+//	func TestSomethingThatUsesFilterClient(t *testing.T) {
 //
-// 		// make and configure a mocked datasetType.FilterClient
-// 		mockedFilterClient := &FilterClientMock{
-// 			GetJobStateFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, downloadServiceToken string, collectionID string, filterID string) (filter.Model, string, error) {
-// 				panic("mock out the GetJobState method")
-// 			},
-// 		}
+//		// make and configure a mocked datasetType.FilterClient
+//		mockedFilterClient := &FilterClientMock{
+//			GetJobStateFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, downloadServiceToken string, collectionID string, filterID string) (filter.Model, string, error) {
+//				panic("mock out the GetJobState method")
+//			},
+//		}
 //
-// 		// use mockedFilterClient in code that requires datasetType.FilterClient
-// 		// and then make assertions.
+//		// use mockedFilterClient in code that requires datasetType.FilterClient
+//		// and then make assertions.
 //
-// 	}
+//	}
 type FilterClientMock struct {
 	// GetJobStateFunc mocks the GetJobState method.
 	GetJobStateFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, downloadServiceToken string, collectionID string, filterID string) (filter.Model, string, error)
@@ -82,7 +82,8 @@ func (mock *FilterClientMock) GetJobState(ctx context.Context, userAuthToken str
 
 // GetJobStateCalls gets all the calls that were made to GetJobState.
 // Check the length with:
-//     len(mockedFilterClient.GetJobStateCalls())
+//
+//	len(mockedFilterClient.GetJobStateCalls())
 func (mock *FilterClientMock) GetJobStateCalls() []struct {
 	Ctx                  context.Context
 	UserAuthToken        string

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -674,3 +674,75 @@ func TestRouter(t *testing.T) {
 		})
 	})
 }
+
+func TestReleaseCalendarFeatureFlag(t *testing.T) {
+	Convey("When a /releases/ request is made", t, func() {
+		babbageHandler := NewHandlerMock()
+		releaseCalendarHandler := NewHandlerMock()
+		legacyCacheProxyHandler := NewHandlerMock()
+
+		config := router.Config{
+			BabbageHandler: babbageHandler,
+			RelCalHandler:  releaseCalendarHandler,
+			ProxyHandler:   legacyCacheProxyHandler,
+		}
+
+		url := "/releases/"
+		res := httptest.NewRecorder()
+
+		Convey("And the release calendar route is enabled", func() {
+			config.RelCalEnabled = true
+
+			Convey("And the new release calendar is used", func() {
+				config.UseNewReleaseCalendar = true
+
+				Convey("And the legacy cache proxy is enabled", func() {
+					config.LegacyCacheProxyEnabled = true
+					req := httptest.NewRequest("GET", url, http.NoBody)
+					r := router.New(config)
+					r.ServeHTTP(res, req)
+
+					Convey("Then the request is sent to legacy cache proxy", func() {
+						So(len(legacyCacheProxyHandler.ServeHTTPCalls()), ShouldEqual, 1)
+					})
+				})
+
+				Convey("And the legacy cache proxy is not enabled", func() {
+					config.LegacyCacheProxyEnabled = false
+					req := httptest.NewRequest("GET", url, http.NoBody)
+					r := router.New(config)
+					r.ServeHTTP(res, req)
+
+					Convey("Then the request is sent to release calendar", func() {
+						So(len(releaseCalendarHandler.ServeHTTPCalls()), ShouldEqual, 1)
+					})
+				})
+			})
+
+			Convey("And the new release calendar is not used", func() {
+				config.UseNewReleaseCalendar = false
+
+				Convey("And the legacy cache proxy is enabled", func() {
+					config.LegacyCacheProxyEnabled = true
+					req := httptest.NewRequest("GET", url, http.NoBody)
+					r := router.New(config)
+					r.ServeHTTP(res, req)
+
+					Convey("Then the request is sent to legacy cache proxy", func() {
+						So(len(legacyCacheProxyHandler.ServeHTTPCalls()), ShouldEqual, 1)
+					})
+				})
+				Convey("And the legacy cache proxy is not enabled", func() {
+					config.LegacyCacheProxyEnabled = false
+					req := httptest.NewRequest("GET", url, http.NoBody)
+					r := router.New(config)
+					r.ServeHTTP(res, req)
+
+					Convey("Then the request is sent to Babbage", func() {
+						So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 1)
+					})
+				})
+			})
+		})
+	})
+}

--- a/router/routertest/handler.go
+++ b/router/routertest/handler.go
@@ -15,19 +15,19 @@ var _ router.Handler = &HandlerMock{}
 
 // HandlerMock is a mock implementation of router.Handler.
 //
-//     func TestSomethingThatUsesHandler(t *testing.T) {
+//	    func TestSomethingThatUsesHandler(t *testing.T) {
 //
-//         // make and configure a mocked router.Handler
-//         mockedHandler := &HandlerMock{
-//             ServeHTTPFunc: func(in1 http.ResponseWriter, in2 *http.Request)  {
-// 	               panic("mock out the ServeHTTP method")
-//             },
-//         }
+//	        // make and configure a mocked router.Handler
+//	        mockedHandler := &HandlerMock{
+//	            ServeHTTPFunc: func(in1 http.ResponseWriter, in2 *http.Request)  {
+//		               panic("mock out the ServeHTTP method")
+//	            },
+//	        }
 //
-//         // use mockedHandler in code that requires router.Handler
-//         // and then make assertions.
+//	        // use mockedHandler in code that requires router.Handler
+//	        // and then make assertions.
 //
-//     }
+//	    }
 type HandlerMock struct {
 	// ServeHTTPFunc mocks the ServeHTTP method.
 	ServeHTTPFunc func(in1 http.ResponseWriter, in2 *http.Request)
@@ -65,7 +65,8 @@ func (mock *HandlerMock) ServeHTTP(in1 http.ResponseWriter, in2 *http.Request) {
 
 // ServeHTTPCalls gets all the calls that were made to ServeHTTP.
 // Check the length with:
-//     len(mockedHandler.ServeHTTPCalls())
+//
+//	len(mockedHandler.ServeHTTPCalls())
 func (mock *HandlerMock) ServeHTTPCalls() []struct {
 	In1 http.ResponseWriter
 	In2 *http.Request


### PR DESCRIPTION
### What

When LegacyCacheProxyEnabled is true release calendar URLs are redirected to dp-legacy-cache-proxy 

### How to review

1. Run dp-frontend-release-calendar with the required apps mentioned in its README
2. Run dp-frontend-router make debug and set LEGACY_CACHE_PROXY_ENABLED=true
3. This requires changes that are part of https://github.com/ONSdigital/dp-legacy-cache-proxy/pull/20 in order to check that the call is made to the dp-legacy-cache-proxy. Checkout the [branch](https://github.com/ONSdigital/dp-legacy-cache-proxy/tree/feature/release-calendar-redirect) on the above PR and run in dp-legacy-cache-proxy make debug
4. Make a request to a release calendar endpoint e.g. http://localhost:20000/releases/adoption

### Who can review

Anyone from ONS
