### PR TITLE
Feature/add route redirector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ debug:
 	go build -tags 'debug' -o $(BINPATH)/dp-frontend-router -ldflags="-X 'main.BuildTime=$(BUILD_TIME)' -X 'main.GitCommit=$(GIT_COMMIT)' -X 'main.Version=$(VERSION)'"
 	HUMAN_LOG=1 DEBUG=1 $(BINPATH)/dp-frontend-router
 
+.PHONY: debug-watch
+debug-watch: 
+	reflex -d none -c ./reflex
+
 .PHONY: debug-run
 debug-run:
 	HUMAN_LOG=1 go run -ldflags "-X main.BuildTime=$(BUILD_TIME) -X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)" -race $(LDFLAGS) main.go

--- a/middleware/redirects/redirects.go
+++ b/middleware/redirects/redirects.go
@@ -97,3 +97,17 @@ func DynamicRedirectHandler(redirectFrom, redirectTo string) http.Handler {
 		http.Redirect(w, req, redirectURL, http.StatusMovedPermanently)
 	})
 }
+
+// RouteRedirectHandler will redirect to the new path provided, this can allow for wildcard redirecting. It also preserves query strings.
+func RouteRedirectHandler(redirectTo string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		redirectURL := redirectTo
+
+		if req.URL.RawQuery != "" {
+			redirectURL += "?" + req.URL.RawQuery
+		}
+
+		log.Info(req.Context(), "redirect found", log.Data{"location": redirectURL}, log.HTTP(req, 0, 0, nil, nil))
+		http.Redirect(w, req, redirectURL, http.StatusMovedPermanently)
+	})
+}

--- a/router/router.go
+++ b/router/router.go
@@ -107,6 +107,17 @@ func New(cfg Config) http.Handler {
 	if cfg.SearchRoutesEnabled {
 		// needs both the SearchRoutesEnabled and DataAggregationPagesEnabled since it relies on the SearchHandler
 		if cfg.DataAggregationPagesEnabled {
+			// These pages used to exist as subpages but we're redirecting to root now as they didn't
+			// do anything.
+			legacyAdhocPagesRedirectHandler := redirects.RouteRedirectHandler("/alladhocs")
+			router.Handle("/{uri:.*}/alladhocs", legacyAdhocPagesRedirectHandler)
+
+			legacyMethodologyRedirectHandler := redirects.RouteRedirectHandler("/allmethodologies")
+			router.Handle("/{uri:.*}/allmethodologies", legacyMethodologyRedirectHandler)
+
+			legacyPublishedRequestsRedirectHandler := redirects.RouteRedirectHandler("/publishedrequests")
+			router.Handle("/{uri:.*}/publishedrequests", legacyPublishedRequestsRedirectHandler)
+
 			router.Handle("/alladhocs", cfg.SearchHandler)
 			router.Handle("/datalist", cfg.SearchHandler)
 			router.Handle("/allmethodologies", cfg.SearchHandler)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -371,7 +371,6 @@ func TestRouter(t *testing.T) {
 			Convey("And the page request has been redirected to the root", func() {
 				So(res.Result().StatusCode, ShouldEqual, 301)
 				So(res.Result().Header.Get("Location"), ShouldEqual, "/alladhocs")
-
 			})
 			Convey("And no request is sent to Babbage", func() {
 				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 0)


### PR DESCRIPTION
### What

We've aggregated the aggregated pages into the root. 

Before, each taxonomy node in Babbage had a /alladhocs endpoint which didn't actually filter. We're not recreating this in the search service so I've added a generic mux handler that will redirect any mux path to a particular path. It also preserves the query string. 

### How to review

If you run the service and access /economy/alladhocs?hello=true you will be redirected to /alladhocs?hello=true

### Who can review

Not me. 