### PR TITLE
Send bulletin extensions through cache proxy

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -148,12 +148,21 @@ func New(cfg Config) http.Handler {
 	}
 
 	if cfg.PreviousReleasesRouteEnabled {
-		router.Handle("/{uri:.*}/previousreleases", cfg.SearchHandler)
+		if cfg.LegacyCacheProxyEnabled {
+			router.Handle("/{uri:.*}/previousreleases", cfg.ProxyHandler)
+		} else {
+			router.Handle("/{uri:.*}/previousreleases", cfg.SearchHandler)
+		}
 	}
 
 	if cfg.RelatedDataRouteEnabled {
-		router.Handle("/{uri:.*}/relateddata", cfg.SearchHandler)
-		router.Handle("/{uri:.*}/relatedData", cfg.SearchHandler)
+		if cfg.LegacyCacheProxyEnabled {
+			router.Handle("/{uri:.*}/relateddata", cfg.ProxyHandler)
+			router.Handle("/{uri:.*}/relatedData", cfg.ProxyHandler)
+		} else {
+			router.Handle("/{uri:.*}/relateddata", cfg.SearchHandler)
+			router.Handle("/{uri:.*}/relatedData", cfg.SearchHandler)
+		}
 	}
 
 	var handler http.Handler

--- a/router/router.go
+++ b/router/router.go
@@ -56,6 +56,7 @@ type Config struct {
 	RelatedDataRouteEnabled      bool
 }
 
+//nolint:gocyclo // This will be reduced once we complete decomm of legacy search and flags can be removed.
 func New(cfg Config) http.Handler {
 	router := mux.NewRouter()
 	middleware := []alice.Constructor{

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -495,11 +495,11 @@ func TestRouter(t *testing.T) {
 			r := router.New(config)
 			r.ServeHTTP(res, req)
 			Convey("Then the request is sent to the search handler", func() {
-				So(len(searchHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(searchHandler.ServeHTTPCalls(), ShouldHaveLength, 1)
 				So(searchHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
 			})
 			Convey("Then no request is sent to Babbage", func() {
-				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 0)
+				So(babbageHandler.ServeHTTPCalls(), ShouldHaveLength, 0)
 			})
 		})
 		Convey("When a related data request is made, the RelatedDataRouteEnabled is enabled and the Legacy Cache Proxy is enabled", func() {
@@ -513,14 +513,14 @@ func TestRouter(t *testing.T) {
 			r := router.New(config)
 			r.ServeHTTP(res, req)
 			Convey("Then the request is sent to the legacy cache proxy", func() {
-				So(len(proxyHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(proxyHandler.ServeHTTPCalls(), ShouldHaveLength, 1)
 				So(proxyHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
 			})
 			Convey("Then no request is sent to Babbage", func() {
-				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 0)
+				So(babbageHandler.ServeHTTPCalls(), ShouldHaveLength, 0)
 			})
 			Convey("Then no request is sent to the Search Handler", func() {
-				So(len(searchHandler.ServeHTTPCalls()), ShouldEqual, 0)
+				So(searchHandler.ServeHTTPCalls(), ShouldHaveLength, 0)
 			})
 		})
 
@@ -536,11 +536,11 @@ func TestRouter(t *testing.T) {
 			r := router.New(config)
 			r.ServeHTTP(res, req)
 			Convey("Then the request is sent to the search handler", func() {
-				So(len(searchHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(searchHandler.ServeHTTPCalls(), ShouldHaveLength, 1)
 				So(searchHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
 			})
 			Convey("Then no request is sent to Babbage", func() {
-				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 0)
+				So(babbageHandler.ServeHTTPCalls(), ShouldHaveLength, 0)
 			})
 		})
 		Convey("When a previous releases request is made, the PreviousReleasesRoute is enabled and the Legacy Cache Proxy is enabled", func() {
@@ -554,14 +554,14 @@ func TestRouter(t *testing.T) {
 			r := router.New(config)
 			r.ServeHTTP(res, req)
 			Convey("Then the request is sent to the legacy cache proxy", func() {
-				So(len(proxyHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(proxyHandler.ServeHTTPCalls(), ShouldHaveLength, 1)
 				So(proxyHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
 			})
 			Convey("Then no request is sent to Babbage", func() {
-				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 0)
+				So(babbageHandler.ServeHTTPCalls(), ShouldHaveLength, 0)
 			})
 			Convey("Then no request is sent to the Search Handler", func() {
-				So(len(searchHandler.ServeHTTPCalls()), ShouldEqual, 0)
+				So(searchHandler.ServeHTTPCalls(), ShouldHaveLength, 0)
 			})
 		})
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -83,6 +83,7 @@ func TestRouter(t *testing.T) {
 		censusAtlasHandler := NewHandlerMock()
 		releaseCalendarHandler := NewHandlerMock()
 		prefixDatasetHandler := NewHandlerMock()
+		proxyHandler := NewHandlerMock()
 
 		zebedeeClient := &allroutestest.ZebedeeClientMock{
 			GetWithHeadersFunc: func(ctx context.Context, userAccessToken string, path string) ([]byte, http.Header, error) {
@@ -120,6 +121,7 @@ func TestRouter(t *testing.T) {
 			HomepageHandler:      homepageHandler,
 			CensusAtlasHandler:   censusAtlasHandler,
 			RelCalHandler:        releaseCalendarHandler,
+			ProxyHandler:         proxyHandler,
 		}
 
 		Convey("When a analytics request is made", func() {
@@ -481,18 +483,17 @@ func TestRouter(t *testing.T) {
 				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 0)
 			})
 		})
-		Convey("When a related data request is made, and the RelatedDataRouteEnabled is enabled", func() {
+		Convey("When a related data request is made, the RelatedDataRouteEnabled is enabled and the Legacy Cache Proxy is disabled", func() {
 			url := "/economy/relateddata"
 			req := httptest.NewRequest("GET", url, http.NoBody)
 			res := httptest.NewRecorder()
 
 			config.RelatedDataRouteEnabled = true
 			config.SearchRoutesEnabled = true
+			config.LegacyCacheProxyEnabled = false
+
 			r := router.New(config)
 			r.ServeHTTP(res, req)
-			Convey("Then no requests are sent to Zebedee", func() {
-				So(len(zebedeeClient.GetWithHeadersCalls()), ShouldEqual, 0)
-			})
 			Convey("Then the request is sent to the search handler", func() {
 				So(len(searchHandler.ServeHTTPCalls()), ShouldEqual, 1)
 				So(searchHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
@@ -501,6 +502,69 @@ func TestRouter(t *testing.T) {
 				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 0)
 			})
 		})
+		Convey("When a related data request is made, the RelatedDataRouteEnabled is enabled and the Legacy Cache Proxy is enabled", func() {
+			url := "/economy/relateddata"
+			req := httptest.NewRequest("GET", url, http.NoBody)
+			res := httptest.NewRecorder()
+
+			config.RelatedDataRouteEnabled = true
+			config.SearchRoutesEnabled = true
+			config.LegacyCacheProxyEnabled = true
+			r := router.New(config)
+			r.ServeHTTP(res, req)
+			Convey("Then the request is sent to the legacy cache proxy", func() {
+				So(len(proxyHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(proxyHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
+			})
+			Convey("Then no request is sent to Babbage", func() {
+				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 0)
+			})
+			Convey("Then no request is sent to the Search Handler", func() {
+				So(len(searchHandler.ServeHTTPCalls()), ShouldEqual, 0)
+			})
+		})
+
+		Convey("When a previous releases request is made, the PreviousReleasesRoute is enabled and the Legacy Cache Proxy is disabled", func() {
+			url := "/economy/previousreleases"
+			req := httptest.NewRequest("GET", url, http.NoBody)
+			res := httptest.NewRecorder()
+
+			config.PreviousReleasesRouteEnabled = true
+			config.SearchRoutesEnabled = true
+			config.LegacyCacheProxyEnabled = false
+
+			r := router.New(config)
+			r.ServeHTTP(res, req)
+			Convey("Then the request is sent to the search handler", func() {
+				So(len(searchHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(searchHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
+			})
+			Convey("Then no request is sent to Babbage", func() {
+				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 0)
+			})
+		})
+		Convey("When a previous releases request is made, the PreviousReleasesRoute is enabled and the Legacy Cache Proxy is enabled", func() {
+			url := "/economy/previousreleases"
+			req := httptest.NewRequest("GET", url, http.NoBody)
+			res := httptest.NewRecorder()
+
+			config.PreviousReleasesRouteEnabled = true
+			config.SearchRoutesEnabled = true
+			config.LegacyCacheProxyEnabled = true
+			r := router.New(config)
+			r.ServeHTTP(res, req)
+			Convey("Then the request is sent to the legacy cache proxy", func() {
+				So(len(proxyHandler.ServeHTTPCalls()), ShouldEqual, 1)
+				So(proxyHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
+			})
+			Convey("Then no request is sent to Babbage", func() {
+				So(len(babbageHandler.ServeHTTPCalls()), ShouldEqual, 0)
+			})
+			Convey("Then no request is sent to the Search Handler", func() {
+				So(len(searchHandler.ServeHTTPCalls()), ShouldEqual, 0)
+			})
+		})
+
 		Convey("When a dataset finder request is made, but the Dataset Finder is not enabled", func() {
 			url := "/census/find-a-dataset"
 			req := httptest.NewRequest("GET", url, http.NoBody)


### PR DESCRIPTION
### What

Routing bulletin/article/compenia extension pages (/previousreleases & /related[Dd]ata) through the legacy cache proxy

### How to review

Check looks ok, tests pass, sufficient coverage, sensible approach. 

To run locally you can run:

- dp-frontend-router
- dp-frontend-search-controller
- babbage (requires es2.4.2)
- dp-legacy-cache-proxy

Use the feature flags to direct traffic different ways.

### Who can review

Not me. 