### PR TITLE
Delete yorksurvey short url

### DIFF
--- a/assets/redirects/redirects.csv
+++ b/assets/redirects/redirects.csv
@@ -334,6 +334,5 @@
 /aboutus/careers,https://careers.ons.gov.uk
 /healthinsightsurvey,/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/healthinsightsurvey
 /atoz,/publications?filter=bulletin&sort=release_date
-/yorksurvey,/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/surveyofresidentsofyorkparticipantinformationsheet
 /grtsurvey,/surveys/informationforhouseholdsandindividuals/householdandindividualsurveys/surveyofpeopleidentifyingasgypsyromaortravellerparticipantinformationsheet
 /peoplepopulationandcommunity/wellbeing/articles/subnationalindicatorsexplorer/2022-01-06,https://explore-local-statistics.beta.ons.gov.uk/


### PR DESCRIPTION
### What

There was a support request as follows:

Deadline: 2024-11-13
Question: Could the short URL https://www.ons.gov.uk/yorksurvey be removed please? It refers to a survey which has expired and the page it leads to will be deleted. Thanks!

### How to review

Check that the correct URL has been deleted from the list.

### Who can review

Anyone but me!