### PR TITLE
Remove unused sixteens library reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
 | SEARCH_ROUTES_ENABLED           | false                                     | Search routes feature toggle                                                             |
 | API_ROUTER_URL                  | <http://localhost:23200/v1>               | The API router URL                                                                       |
 | DOWNLOADER_URL                  | <http://localhost:23400>                  | The URL of dp-file-downloader.                                                           |
-| PATTERN_LIBRARY_ASSETS_PATH     | <https://cdn.ons.gov.uk/sixteens/e42235b> | The URL to the sixteens build to use                                                     |
 | SITE_DOMAIN                     | ons.gov.uk                                | The domain hosting the site                                                              |
 | CONTENT_TYPE_BYTE_LIMIT         | 5000000 (5MB)                             | Response size at which we stop checking content-type to avoid oom errors                 |
 | HEALTHCHECK_INTERVAL            | 30s                                       | The period of time between health checks                                                 |

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,6 @@ type Config struct {
 	OTServiceName                string        `envconfig:"OTEL_SERVICE_NAME"`
 	OTBatchTimeout               time.Duration `envconfig:"OTEL_BATCH_TIMEOUT"`
 	OtelEnabled                  bool          `envconfig:"OTEL_ENABLED"`
-	PatternLibraryAssetsPath     string        `envconfig:"PATTERN_LIBRARY_ASSETS_PATH"`
 	PreviousReleasesRouteEnabled bool          `envconfig:"PREVIOUS_RELEASES_ROUTE_ENABLED"`
 	ProxyTimeout                 time.Duration `envconfig:"PROXY_TIMEOUT"`
 	RelatedDataRouteEnabled      bool          `envconfig:"RELATED_DATA_ROUTE_ENABLED"`
@@ -83,7 +82,6 @@ func Get() (*Config, error) {
 		OTServiceName:                "dp-frontend-router",
 		OTBatchTimeout:               5 * time.Second,
 		OtelEnabled:                  false,
-		PatternLibraryAssetsPath:     "https://cdn.ons.gov.uk/sixteens/f816ac8",
 		PreviousReleasesRouteEnabled: false,
 		ProxyTimeout:                 5 * time.Second,
 		RelatedDataRouteEnabled:      false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,7 +33,6 @@ func TestSpec(t *testing.T) {
 				So(cfg.APIRouterURL, ShouldEqual, "http://localhost:23200/v1")
 				So(cfg.DownloaderURL, ShouldEqual, "http://localhost:23400")
 				So(cfg.FilterFlexDatasetServiceURL, ShouldEqual, "http://localhost:20100")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "https://cdn.ons.gov.uk/sixteens/f816ac8")
 				So(cfg.SiteDomain, ShouldEqual, "ons.gov.uk")
 				So(cfg.ContentTypeByteLimit, ShouldEqual, 5000000)
 				So(cfg.HealthcheckInterval, ShouldEqual, 30*time.Second)


### PR DESCRIPTION
### What

Removed unused pattern library reference (used to be used for 404s but now deprecated)

### How to review

Check haven't removed anything needed.

### Who can review

Not me. 