### PR TITLE
Remove dataset filter type checks from middleware

### DIFF
--- a/middleware/datasetType/handler.go
+++ b/middleware/datasetType/handler.go
@@ -3,13 +3,9 @@ package datasetType
 
 import (
 	"context"
-	"net/http"
-	"strings"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
-	"github.com/ONSdigital/dp-frontend-router/helpers"
-	"github.com/ONSdigital/log.go/v2/log"
 )
 
 //go:generate moq -out mocks/filter.go -pkg mocks . FilterClient
@@ -23,50 +19,4 @@ type FilterClient interface {
 // DatasetClient is an interface with methods required for a dataset client
 type DatasetClient interface {
 	Get(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID string) (m dataset.DatasetDetails, err error)
-}
-
-// Handler is middleware that a accepts a filter and dataset client that returns either the filter or filterFlex handler dependent on the type of dataset
-func Handler(filterClient FilterClient, datasetClient DatasetClient) func(filter, filterFlex http.Handler) http.Handler {
-	return func(filter, filterFlex http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			path := req.URL.Path
-			ctx := req.Context()
-
-			filterID, err := helpers.ReturnSecondSegmentFromPath(path)
-			if err != nil {
-				log.Error(ctx, "failed to extract filter id info from path", err, log.Data{"filter_id": filterID, "path": path})
-				return
-			}
-
-			// Obtain access_token from cookie
-			userAccessToken := ""
-			c, err := req.Cookie(`access_token`)
-			if err == nil && c.Value != "" {
-				userAccessToken = c.Value
-				log.Info(req.Context(), "obtained access_token Cookie")
-			}
-
-			f, _, err := filterClient.GetJobState(ctx, userAccessToken, "", "", "", filterID)
-			if err != nil {
-				log.Warn(ctx, "failed to get job state - falling through to default handling", log.Data{"filter_id": filterID})
-				filter.ServeHTTP(w, req)
-				return
-			}
-
-			d, err := datasetClient.Get(ctx, userAccessToken, "", "", f.Dataset.DatasetID)
-			if err != nil {
-				log.Warn(ctx, "failed to get dataset id - falling through to default handling", log.Data{"dataset_id": f.Dataset.DatasetID})
-				filter.ServeHTTP(w, req)
-				return
-			}
-
-			if strings.Contains(d.Type, "cantabular") {
-				log.Info(ctx, "using flex handler")
-				filterFlex.ServeHTTP(w, req)
-				return
-			}
-			log.Info(ctx, "using filter handler")
-			filter.ServeHTTP(w, req)
-		})
-	}
 }

--- a/router/router.go
+++ b/router/router.go
@@ -94,7 +94,6 @@ func New(cfg Config) http.Handler {
 	router.Handle("/download/{uri:.*}", cfg.DownloadHandler)
 	router.Handle("/cookies{uri:.*}", cfg.CookieHandler)
 	router.Handle("/datasets/{uri:.*}", cfg.DatasetHandler)
-	router.Handle("/filters/{uri:.*}", datasetType.Handler(cfg.FilterClient, cfg.DatasetClient)(cfg.FilterHandler, cfg.FilterFlexHandler))
 	router.Handle("/filter-outputs/{uri:.*}", cfg.FilterHandler)
 	router.Handle("/feedback{uri:.*}", cfg.FeedbackHandler)
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -198,15 +198,6 @@ func TestRouter(t *testing.T) {
 			r := router.New(config)
 			r.ServeHTTP(res, req)
 
-			Convey("Then no requests are sent to Zebedee", func() {
-				So(zebedeeClient.GetWithHeadersCalls(), ShouldHaveLength, 0)
-			})
-
-			Convey("Then the request is sent to the filter handler", func() {
-				So(filterHandler.ServeHTTPCalls(), ShouldHaveLength, 1)
-				So(filterHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
-			})
-
 			Convey("Then no requests are sent to the filter/flex handler", func() {
 				So(filterFlexHandler.ServeHTTPCalls(), ShouldHaveLength, 0)
 			})
@@ -227,15 +218,6 @@ func TestRouter(t *testing.T) {
 
 			r := router.New(config)
 			r.ServeHTTP(res, req)
-
-			Convey("Then no requests are sent to Zebedee", func() {
-				So(len(zebedeeClient.GetWithHeadersCalls()), ShouldEqual, 0)
-			})
-
-			Convey("Then the request is sent to the filter/flex handler", func() {
-				So(filterFlexHandler.ServeHTTPCalls(), ShouldHaveLength, 1)
-				So(filterFlexHandler.ServeHTTPCalls()[0].In2.URL.Path, ShouldResemble, url)
-			})
 
 			Convey("Then no requests are sent to the filter handler", func() {
 				So(filterHandler.ServeHTTPCalls(), ShouldHaveLength, 0)


### PR DESCRIPTION
### What

There is currently a check in dp-frontend-router that determines the type of a dataset or a filter, and routes to either dp-frontend-filter-flex-dataset or dp-frontend-filter-dataset-controller depending on the dataset type. This check was removed from the frontend-router and moved to dp-frontend-dataset-controller (which is the calling service), as the frontend-router should behave as a forwarding service only without any business logic.

https://jira.ons.gov.uk/browse/DIS-3020

### How to review
Set up dp-compose to utilise `dp-frontend-router` within the `datacatalogue` stack. And set the `API_ROUTER_URL` env variable for both `dp-dataset-router` and `dp-frontend-dataset-controller` to `https://api.dp.aws.onsdigital.uk/v1` . This will point the services directly at the data in sandbox so that the cantabular and CMD pages can be tested locally. 

The behaviour that needs to be tested is:

- When a cantabular dataset landing page is accessed, and "change" is clicked alongside one of the variables, then the dp-frontend-filter-flex-dataset service is called, and the cantabular filter-flex journey works as it currently does.
- When a CMD dataset landing page is accessed, and "Filter and download" is clicked, then the dp-frontend-dataset-controller service is called, and the CMD filter journey works as it currently does.

To access the pages for testing, use the following: 
- Cantabular dataset landing page - https://dp.aws.onsdigital.uk/datasets/RM021/editions/2021/versions/32
- CMD dataset landing page - https://dp.aws.onsdigital.uk/datasets/cpih01/editions/time-series/versions/2

### Who can review

Anyone
