### PR TITLE
Change version of dp-api-clients-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-router
 go 1.26
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.273.0
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-net/v3 v3.10.0
 	github.com/ONSdigital/dp-otel-go v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0 h1:wJ+lfVqF7rDksQ+p6adHqoXvE0Q/4ZDfifxzLC16Vh8=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.277.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.273.0 h1:iCn+HYkqYDTrzBuwDuvbUYCrIpOrRcVaRsMaATEpxJs=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.273.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
 github.com/ONSdigital/dp-healthcheck v1.6.4 h1:FhWOuVmob36dYq7AzCdbgyf0Vk58IFitSl8y8pWJ8ck=
 github.com/ONSdigital/dp-healthcheck v1.6.4/go.mod h1:j3UNbGT4ZJg1chrRkPLE6YUVYCg1su3AAQ8frcBrvgc=
 github.com/ONSdigital/dp-mocking v0.11.0 h1:laln6e2JD4vtsYbg0cTw9ur1Xf390AUYdd85cG2UNQw=


### PR DESCRIPTION
### What

Change version of dp-api-clients-go to 2.273.0 as [per](https://onswebsite.slack.com/archives/C051DH0CPT3/p1776245418494579?thread_ts=1776077570.127689&cid=C051DH0CPT3) 

### How to review

Sense check

### Who can review

Not me